### PR TITLE
fix: pin all container image versions

### DIFF
--- a/.forgejo/workflows/test.yml
+++ b/.forgejo/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test-go:
     runs-on: docker
     container:
-      image: golang:1.24-alpine
+      image: golang:1.24.2-alpine
     steps:
       - name: Install Node.js
         run: apk add --no-cache nodejs npm
@@ -25,7 +25,7 @@ jobs:
   build-ui:
     runs-on: docker
     container:
-      image: golang:1.24-alpine
+      image: golang:1.24.2-alpine
     steps:
       - name: Install Node.js
         run: apk add --no-cache nodejs npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test-go:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-alpine
+      image: golang:1.24.2-alpine
     steps:
       - name: Install Node.js
         run: apk add --no-cache nodejs npm
@@ -25,7 +25,7 @@ jobs:
   build-ui:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-alpine
+      image: golang:1.24.2-alpine
     steps:
       - name: Install Node.js
         run: apk add --no-cache nodejs npm

--- a/apps/authentik/module.nix
+++ b/apps/authentik/module.nix
@@ -68,7 +68,7 @@ in
   config = lib.mkIf appCfg.enable {
     bloud.pullImages = [
       "ghcr.io/goauthentik/server:2025.10.3"
-      "nginx:alpine"
+      "nginx:1.27.5-alpine"
     ] ++ lib.optionals appCfg.ldap.enable [
       "ghcr.io/goauthentik/ldap:2025.10.3"
     ];
@@ -211,7 +211,7 @@ in
       # so we must wait for apps-authentik-server to be healthy before starting.
       podman-apps-authentik-proxy = mkPodmanService {
         name = "apps-authentik-proxy";
-        image = "nginx:alpine";
+        image = "nginx:1.27.5-alpine";
         volumes = [
           "${configPath}/authentik-proxy.conf:/etc/nginx/conf.d/default.conf:ro"
         ];

--- a/apps/jellyfin/module.nix
+++ b/apps/jellyfin/module.nix
@@ -14,7 +14,7 @@ mkPodmanApp {
   name = "jellyfin";
   description = "Free software media system for streaming movies, TV, and music";
 
-  image = "jellyfin/jellyfin:latest";
+  image = "jellyfin/jellyfin:10.11.7";
   port = 8096;
 
   environment = cfg: {

--- a/apps/miniflux/module.nix
+++ b/apps/miniflux/module.nix
@@ -8,7 +8,7 @@ in
 mkPodmanApp {
   name = "miniflux";
   description = "Miniflux RSS reader";
-  image = "miniflux/miniflux:latest";
+  image = "miniflux/miniflux:2.2.18";
   port = 8085;
   network = "host";
   database = "miniflux";

--- a/apps/qbittorrent/module.nix
+++ b/apps/qbittorrent/module.nix
@@ -8,7 +8,7 @@ in
 mkPodmanApp {
   name = "qbittorrent";
   description = "BitTorrent client with web UI";
-  image = "lscr.io/linuxserver/qbittorrent:latest";
+  image = "lscr.io/linuxserver/qbittorrent:5.1.4-r2-ls447";
   port = 8086;
   containerPort = 8080;
 

--- a/nixos/lib/podman-app.nix
+++ b/nixos/lib/podman-app.nix
@@ -11,7 +11,7 @@
 #   mkPodmanApp {
 #     name = "myapp";
 #     description = "My App description";
-#     image = "myapp/myapp:latest";
+#     image = "myapp/myapp:1.0.0";
 #     port = 8080;
 #     # ... see parameters below
 #   }


### PR DESCRIPTION
## Summary

Closes #12

- Replace `nginx:alpine` → `nginx:1.27.5-alpine` (authentik proxy)
- Replace `miniflux/miniflux:latest` → `miniflux/miniflux:2.2.18`
- Replace `jellyfin/jellyfin:latest` → `jellyfin/jellyfin:10.11.7`
- Replace `lscr.io/linuxserver/qbittorrent:latest` → `lscr.io/linuxserver/qbittorrent:5.1.4-r2-ls447`
- Replace `golang:1.24-alpine` → `golang:1.24.2-alpine` (CI workflows, both GitHub and Forgejo)
- Update `podman-app.nix` documentation example to not use `:latest`

All images are now referenced with explicit version tags, ensuring reproducible and predictable deployments.

## Test plan

- [ ] Verify `nix flake check` still passes (no Nix eval errors from image string changes)
- [ ] Verify existing smoke/CI tests pass