### PR TITLE
fix: use catalog ID for forward-auth SSO provisioning

### DIFF
--- a/services/host-agent/internal/orchestrator/mocks_test.go
+++ b/services/host-agent/internal/orchestrator/mocks_test.go
@@ -294,6 +294,16 @@ func (m *MockAuthentikClient) GetLDAPOutpostToken() (string, error) {
 	return args.String(0), args.Error(1)
 }
 
+// MockSSOProvisioner implements orchestrator.SSOProvisioner for testing
+type MockSSOProvisioner struct {
+	mock.Mock
+}
+
+func (m *MockSSOProvisioner) EnsureForwardAuth(appName, displayName, externalURL string) error {
+	args := m.Called(appName, displayName, externalURL)
+	return args.Error(0)
+}
+
 // MockConfiguratorRegistry implements configurator.RegistryInterface for testing
 type MockConfiguratorRegistry struct {
 	mock.Mock
@@ -416,4 +426,3 @@ func (m *MockContainerRuntime) Exec(ctx context.Context, name string, cmd []stri
 	args := m.Called(ctx, name, cmd)
 	return args.Error(0)
 }
-

--- a/services/host-agent/internal/orchestrator/orchestrator.go
+++ b/services/host-agent/internal/orchestrator/orchestrator.go
@@ -35,7 +35,7 @@ type OrchestratorStatus struct {
 // ActivityEvent records a single orchestrator lifecycle event.
 type ActivityEvent struct {
 	Time   time.Time `json:"time"`
-	Event  string    `json:"event"`  // "intent_enqueued", "drain_complete", "converge_start", "converge_step", "converge_complete"
+	Event  string    `json:"event"` // "intent_enqueued", "drain_complete", "converge_start", "converge_step", "converge_complete"
 	Detail string    `json:"detail"`
 }
 
@@ -111,15 +111,15 @@ type Orchestrator struct {
 	config   OrchestratorConfig
 
 	// Intent processing fields
-	queue          *IntentQueue
-	appStore       store.AppStoreInterface
-	catalogGraph   catalog.AppGraphInterface
-	tailnetStore   store.TailnetStoreInterface
-	remoteAppStore store.RemoteAppStoreInterface
-	tailnetNode    TailnetNodeEnsurer
-	gateway        GatewayManager
-	remoteProxy    RemoteProxyManager
-	proxyOutpost   ProxyOutpostEnsurer
+	queue            *IntentQueue
+	appStore         store.AppStoreInterface
+	catalogGraph     catalog.AppGraphInterface
+	tailnetStore     store.TailnetStoreInterface
+	remoteAppStore   store.RemoteAppStoreInterface
+	tailnetNode      TailnetNodeEnsurer
+	gateway          GatewayManager
+	remoteProxy      RemoteProxyManager
+	proxyOutpost     ProxyOutpostEnsurer
 	forwardDomainSSO ForwardDomainProvisioner
 	sso              SSOProvisioner
 	ssoBaseURL       string
@@ -875,19 +875,21 @@ func (o *Orchestrator) ensureSSO(ctx context.Context, id string) error {
 	if o.sso == nil || o.ssoBaseURL == "" || o.catalog == nil {
 		return nil
 	}
-	catalogApp, err := o.catalog.Get(id)
-	if (err != nil || catalogApp == nil) && o.ownerApp(id) != id {
-		catalogApp, err = o.catalog.Get(o.ownerApp(id))
-	}
+	// Use the owning app's catalog ID for subdomain and provider name. Graph
+	// nodes are container names (e.g. "apps-navidrome") for apps defined with a
+	// containers list, while routing and Authentik must use the catalog ID
+	// ("navidrome") so forward-auth matches the app's real subdomain.
+	appID := o.ownerApp(id)
+	catalogApp, err := o.catalog.Get(appID)
 	if err != nil || catalogApp == nil {
 		return nil
 	}
 	if catalogApp.SSO.Strategy != "forward-auth" {
 		return nil
 	}
-	o.logger.Info("provisioning forward-auth SSO", "app", id)
-	externalURL := buildAppSubdomainURL(o.ssoBaseURL, id)
-	return o.sso.EnsureForwardAuth(id, catalogApp.DisplayName, externalURL)
+	o.logger.Info("provisioning forward-auth SSO", "app", appID)
+	externalURL := buildAppSubdomainURL(o.ssoBaseURL, appID)
+	return o.sso.EnsureForwardAuth(appID, catalogApp.DisplayName, externalURL)
 }
 
 // buildAppSubdomainURL constructs the app's subdomain URL from a base URL.
@@ -900,4 +902,3 @@ func buildAppSubdomainURL(baseURL, appName string) string {
 	parsed.Host = appName + "." + parsed.Host
 	return parsed.String()
 }
-

--- a/services/host-agent/internal/orchestrator/orchestrator_test.go
+++ b/services/host-agent/internal/orchestrator/orchestrator_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	containerruntime "codeberg.org/d-buckner/bloud/services/host-agent/internal/container"
 	"codeberg.org/d-buckner/bloud/services/host-agent/internal/catalog"
+	containerruntime "codeberg.org/d-buckner/bloud/services/host-agent/internal/container"
 	"codeberg.org/d-buckner/bloud/services/host-agent/internal/graph"
 )
 
@@ -629,4 +629,48 @@ func TestOrchestrator_PreStartNotChanged_NoContainerRemove(t *testing.T) {
 	node, err := g.GetNode(containerName)
 	require.NoError(t, err)
 	assert.Equal(t, graph.StatusRunning, node.ActualStatus)
+}
+
+// TestOrchestrator_EnsureSSO_UsesCatalogIDForContainerNode verifies that forward-auth
+// SSO provisioning uses the owning app's catalog ID rather than the container node
+// name when building the external URL and provider name. Regression test: navidrome's
+// graph node is "apps-navidrome" but Authentik must be configured for "navidrome.localhost".
+func TestOrchestrator_EnsureSSO_UsesCatalogIDForContainerNode(t *testing.T) {
+	g := graph.New(graph.NewMapRepository())
+	registry := new(MockConfiguratorRegistry)
+	catalogCache := new(MockCatalogCache)
+	ssoMock := new(MockSSOProvisioner)
+
+	orch := NewOrchestrator(
+		g,
+		registry,
+		catalogCache,
+		"/tmp/bloud-test",
+		newTestLogger(),
+		OrchestratorConfig{
+			SSO:                ssoMock,
+			SSOBaseURL:         "http://localhost:8080",
+			HealthCheckTimeout: 100 * time.Millisecond,
+		},
+	)
+
+	// navidrome is defined with a containers list, so its graph node is the
+	// container name "apps-navidrome", owned by catalog ID "navidrome".
+	containerName := "apps-navidrome"
+	orch.registerContainerOwner(containerName, "navidrome")
+
+	catalogCache.On("Get", "navidrome").Return(&catalog.App{
+		CatalogID:   "navidrome",
+		DisplayName: "Navidrome",
+		Port:        4533,
+		SSO:         catalog.SSO{Strategy: "forward-auth"},
+	}, nil)
+
+	ssoMock.On("EnsureForwardAuth", "navidrome", "Navidrome", "http://navidrome.localhost:8080").
+		Return(nil)
+
+	require.NoError(t, orch.ensureSSO(context.Background(), containerName))
+
+	ssoMock.AssertExpectations(t)
+	ssoMock.AssertCalled(t, "EnsureForwardAuth", "navidrome", "Navidrome", "http://navidrome.localhost:8080")
 }


### PR DESCRIPTION
## Problem

Navidrome at `navidrome.localhost:8080` returned Authentik's "Not Found / Go home" 404 page instead of the app, while Jellyfin and other apps routed correctly.

## Root Cause

`ensureSSO` built the Authentik forward-auth provider name and `external_host` from the **graph node ID**, which is the container name (`apps-navidrome`) for apps defined with a `containers:` list. Traefik routes requests with the catalog-ID-based Host header (`navidrome.localhost`), so the embedded outpost never matched real requests and requests fell through to Authentik's web-app 404.

## Fix

Resolve the owning app's catalog ID once via `ownerApp` and use it consistently for the catalog lookup, subdomain URL, and provider name in `ensureSSO`.

## Testing

- Added `MockSSOProvisioner` and regression test `TestOrchestrator_EnsureSSO_UsesCatalogIDForContainerNode`
- Full test suite passes (505 Go + 29 app + 28 TS tests)
- Verified live: `curl -H "Host: navidrome.localhost:8080"` now returns 302 to Authentik authorize instead of 404