### PR TITLE
feat: support attaching containers to multiple networks

### DIFF
--- a/services/host-agent/internal/container/quadlet.go
+++ b/services/host-agent/internal/container/quadlet.go
@@ -141,8 +141,13 @@ func (r *QuadletRuntime) unitName(name string) string {
 }
 
 func renderQuadlet(spec Spec, revision, wantedBy string) ([]byte, error) {
-	if strings.ContainsAny(spec.Name+spec.Image+spec.Network+wantedBy, "\r\n") {
+	if strings.ContainsAny(spec.Name+spec.Image+wantedBy, "\r\n") {
 		return nil, fmt.Errorf("quadlet fields may not contain newlines")
+	}
+	for _, network := range spec.Networks {
+		if strings.ContainsAny(network, "\r\n") {
+			return nil, fmt.Errorf("quadlet network may not contain newlines")
+		}
 	}
 	var out strings.Builder
 	fmt.Fprintf(&out, "[Unit]\nDescription=Bloud container %s\n", spec.Name)
@@ -151,8 +156,8 @@ func renderQuadlet(spec Spec, revision, wantedBy string) ([]byte, error) {
 	}
 	fmt.Fprintf(&out, "\n[Container]\n")
 	fmt.Fprintf(&out, "ContainerName=%s\nImage=%s\nPull=never\nCgroupsMode=disabled\n", spec.Name, spec.Image)
-	if spec.Network != "" {
-		fmt.Fprintf(&out, "Network=%s\n", spec.Network)
+	for _, network := range spec.Networks {
+		fmt.Fprintf(&out, "Network=%s\n", network)
 	}
 	for _, port := range spec.Ports {
 		protocol := port.Protocol

--- a/services/host-agent/internal/container/quadlet_test.go
+++ b/services/host-agent/internal/container/quadlet_test.go
@@ -40,7 +40,7 @@ func TestQuadletRuntimeWritesAndConvergesManagedUnit(t *testing.T) {
 	unitDir := t.TempDir()
 	runtime := newQuadletRuntime(client, manager, unitDir, "default.target")
 	spec := Spec{
-		Name: "apps-jellyfin", Image: "jellyfin:1", Network: "apps-net", RestartPolicy: "always",
+		Name: "apps-jellyfin", Image: "jellyfin:1", Networks: []string{"apps-net"}, RestartPolicy: "always",
 		Environment: map[string]string{"TZ": "Etc/UTC"},
 		Ports:       []Port{{Host: 8096, Container: 8096}},
 		Mounts:      []Mount{{Source: "/data/jellyfin/config", Destination: "/config"}},
@@ -123,7 +123,7 @@ func TestQuadletRuntimeRestartsChangedManagedContainerAndRemovesUnit(t *testing.
 
 func TestQuadletRendersDependsOn(t *testing.T) {
 	spec := Spec{
-		Name: "ts-jellyfin", Image: "tailscale:latest", Network: "apps-net",
+		Name: "ts-jellyfin", Image: "tailscale:latest", Networks: []string{"apps-net"},
 		DependsOn: "apps-jellyfin.service",
 	}
 	content, err := renderQuadlet(spec, "rev", "default.target")
@@ -140,6 +140,29 @@ func TestQuadletOmitsDependsOnWhenEmpty(t *testing.T) {
 	s := string(content)
 	assert.NotContains(t, s, "After=")
 	assert.NotContains(t, s, "BindsTo=")
+}
+
+func TestQuadletRendersMultipleNetworks(t *testing.T) {
+	spec := Spec{
+		Name:     "apps-authentik-ldap",
+		Image:    "ghcr.io/goauthentik/ldap:2025.10.3",
+		Networks: []string{"authentik-internal", "apps-net"},
+	}
+	content, err := renderQuadlet(spec, "rev", "default.target")
+	require.NoError(t, err)
+	s := string(content)
+	assert.Contains(t, s, "Network=authentik-internal\n")
+	assert.Contains(t, s, "Network=apps-net\n")
+}
+
+func TestQuadletRejectsNewlineInNetworkName(t *testing.T) {
+	spec := Spec{
+		Name:     "apps-authentik-ldap",
+		Image:    "ghcr.io/goauthentik/ldap:2025.10.3",
+		Networks: []string{"apps-net\nNetwork=evil-net"},
+	}
+	_, err := renderQuadlet(spec, "rev", "default.target")
+	require.ErrorContains(t, err, "newline")
 }
 
 func TestQuadletRuntimeRemovesUnloadedUnit(t *testing.T) {

--- a/services/host-agent/internal/container/runtime.go
+++ b/services/host-agent/internal/container/runtime.go
@@ -23,7 +23,7 @@ type Spec struct {
 	Ports         []Port
 	Mounts        []Mount
 	Labels        map[string]string
-	Network       string
+	Networks      []string
 	Command       []string
 	RestartPolicy string
 	DependsOn     string // systemd unit to bind lifecycle to (e.g. "apps-jellyfin.service")
@@ -214,7 +214,7 @@ func toPodmanConfig(spec Spec, revision string) podman.ContainerConfig {
 		Image:         spec.Image,
 		Env:           spec.Environment,
 		Labels:        labels,
-		Network:       spec.Network,
+		Networks:      spec.Networks,
 		Command:       spec.Command,
 		RestartPolicy: spec.RestartPolicy,
 	}

--- a/services/host-agent/internal/orchestrator/orchestrator_containers.go
+++ b/services/host-agent/internal/orchestrator/orchestrator_containers.go
@@ -169,10 +169,16 @@ func ContainerSpecFromDef(def catalog.ContainerDef, appCatalogID string, dataDir
 		return value
 	}
 
-	// Use Network (singular) if set; fall back to first entry of Networks (plural).
-	network := def.Network
-	if network == "" && len(def.Networks) > 0 {
-		network = def.Networks[0]
+	// Collect all networks the container should attach to, preserving the
+	// singular Network (if set) before the plural Networks list.
+	var networks []string
+	if def.Network != "" {
+		networks = append(networks, def.Network)
+	}
+	for _, n := range def.Networks {
+		if n != def.Network {
+			networks = append(networks, n)
+		}
 	}
 
 	env := make(map[string]string, len(def.Environment))
@@ -184,7 +190,7 @@ func ContainerSpecFromDef(def catalog.ContainerDef, appCatalogID string, dataDir
 		Name:          def.Name,
 		Image:         def.Image,
 		Environment:   env,
-		Network:       network,
+		Networks:      networks,
 		Command:       def.Command,
 		RestartPolicy: def.RestartPolicy,
 		Labels:        map[string]string{"io.bloud.app": appCatalogID},

--- a/services/host-agent/internal/orchestrator/orchestrator_test.go
+++ b/services/host-agent/internal/orchestrator/orchestrator_test.go
@@ -674,3 +674,49 @@ func TestOrchestrator_EnsureSSO_UsesCatalogIDForContainerNode(t *testing.T) {
 	ssoMock.AssertExpectations(t)
 	ssoMock.AssertCalled(t, "EnsureForwardAuth", "navidrome", "Navidrome", "http://navidrome.localhost:8080")
 }
+
+func TestContainerSpecFromDef_CollectsAllNetworks(t *testing.T) {
+	def := catalog.ContainerDef{
+		Name:    "apps-authentik-ldap",
+		Image:   "ghcr.io/goauthentik/ldap:2025.10.3",
+		Network: "authentik-internal",
+		Networks: []string{
+			"authentik-internal",
+			"apps-net",
+		},
+		Environment: map[string]string{"AUTHENTIK_HOST": "http://apps-authentik-server:9000"},
+	}
+
+	spec, err := ContainerSpecFromDef(def, "authentik", "/var/tmp/bloud", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "apps-authentik-ldap", spec.Name)
+	assert.Equal(t, []string{"authentik-internal", "apps-net"}, spec.Networks)
+	assert.Equal(t, map[string]string{"io.bloud.app": "authentik"}, spec.Labels)
+	assert.Equal(t, "http://apps-authentik-server:9000", spec.Environment["AUTHENTIK_HOST"])
+}
+
+func TestContainerSpecFromDef_SingularNetworkOnly(t *testing.T) {
+	def := catalog.ContainerDef{
+		Name:    "apps-jellyfin",
+		Image:   "jellyfin:latest",
+		Network: "apps-net",
+	}
+
+	spec, err := ContainerSpecFromDef(def, "jellyfin", "/var/tmp/bloud", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"apps-net"}, spec.Networks)
+}
+
+func TestContainerSpecFromDef_NoNetwork(t *testing.T) {
+	def := catalog.ContainerDef{
+		Name:  "apps-worker",
+		Image: "worker:latest",
+	}
+
+	spec, err := ContainerSpecFromDef(def, "myapp", "/var/tmp/bloud", nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, spec.Networks)
+}

--- a/services/host-agent/internal/podman/client.go
+++ b/services/host-agent/internal/podman/client.go
@@ -31,7 +31,7 @@ type ContainerConfig struct {
 	Ports         []PortMapping     `json:"portmappings,omitempty"`
 	Volumes       []VolumeMount     `json:"mounts,omitempty"`
 	Labels        map[string]string `json:"labels,omitempty"`
-	Network       string            `json:"network,omitempty"`
+	Networks      []string          `json:"networks,omitempty"`
 	Command       []string          `json:"command,omitempty"`
 	RestartPolicy string            `json:"restart_policy,omitempty"`
 }
@@ -477,16 +477,19 @@ func buildContainerSpec(config ContainerConfig) map[string]interface{} {
 	if len(config.Labels) > 0 {
 		spec["labels"] = config.Labels
 	}
-	switch config.Network {
-	case "host":
-		spec["netns"] = map[string]interface{}{"nsmode": "host"}
-	case "":
+	// Networks
+	switch {
+	case len(config.Networks) == 0:
 		// default networking
+	case len(config.Networks) == 1 && config.Networks[0] == "host":
+		spec["netns"] = map[string]interface{}{"nsmode": "host"}
 	default:
 		spec["netns"] = map[string]interface{}{"nsmode": "bridge"}
-		spec["networks"] = map[string]map[string]interface{}{
-			config.Network: {},
+		networks := make(map[string]map[string]interface{}, len(config.Networks))
+		for _, network := range config.Networks {
+			networks[network] = map[string]interface{}{}
 		}
+		spec["networks"] = networks
 	}
 	if len(config.Command) > 0 {
 		spec["command"] = config.Command

--- a/services/host-agent/internal/podman/client_test.go
+++ b/services/host-agent/internal/podman/client_test.go
@@ -327,3 +327,48 @@ func TestBuildContainerSpec(t *testing.T) {
 	labels := spec["labels"].(map[string]string)
 	assert.Equal(t, "test", labels["app"])
 }
+
+func TestBuildContainerSpec_MultipleNetworks(t *testing.T) {
+	config := ContainerConfig{
+		Name:     "test-app",
+		Image:    "nginx:latest",
+		Networks: []string{"authentik-internal", "apps-net"},
+	}
+
+	spec := buildContainerSpec(config)
+
+	netns, ok := spec["netns"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "bridge", netns["nsmode"])
+	networks, ok := spec["networks"].(map[string]map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, networks, "authentik-internal")
+	assert.Contains(t, networks, "apps-net")
+}
+
+func TestBuildContainerSpec_HostNetwork(t *testing.T) {
+	config := ContainerConfig{
+		Name:     "test-app",
+		Image:    "tailscale:latest",
+		Networks: []string{"host"},
+	}
+
+	spec := buildContainerSpec(config)
+
+	netns, ok := spec["netns"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "host", netns["nsmode"])
+	assert.NotContains(t, spec, "networks")
+}
+
+func TestBuildContainerSpec_DefaultNetwork(t *testing.T) {
+	config := ContainerConfig{
+		Name:  "test-app",
+		Image: "nginx:latest",
+	}
+
+	spec := buildContainerSpec(config)
+
+	assert.NotContains(t, spec, "netns")
+	assert.NotContains(t, spec, "networks")
+}

--- a/services/host-agent/internal/sharing/gateway.go
+++ b/services/host-agent/internal/sharing/gateway.go
@@ -94,9 +94,9 @@ func (m *GatewayManager) EnsureRunning(ctx context.Context) error {
 	}
 
 	spec := container.Spec{
-		Name:    gatewayContainerName,
-		Image:   TailscaleImage,
-		Network: "host",
+		Name:     gatewayContainerName,
+		Image:    TailscaleImage,
+		Networks: []string{"host"},
 		Environment: map[string]string{
 			"TS_AUTHKEY":       authKey,
 			"TS_HOSTNAME":      "bloud",

--- a/services/host-agent/internal/sharing/gateway_test.go
+++ b/services/host-agent/internal/sharing/gateway_test.go
@@ -22,7 +22,7 @@ func TestGateway_EnsureRunning_CreatesContainerSpec(t *testing.T) {
 
 	assert.Equal(t, "ts-gateway", spec.Name)
 	assert.Equal(t, TailscaleImage, spec.Image)
-	assert.Equal(t, "host", spec.Network)
+	assert.Equal(t, []string{"host"}, spec.Networks)
 	assert.Equal(t, "tskey-auth-gw", spec.Environment["TS_AUTHKEY"])
 	assert.Equal(t, "bloud", spec.Environment["TS_HOSTNAME"])
 	assert.Equal(t, "true", spec.Environment["TS_USERSPACE"])

--- a/services/host-agent/internal/sharing/proxy_outpost.go
+++ b/services/host-agent/internal/sharing/proxy_outpost.go
@@ -54,9 +54,9 @@ func (m *ProxyOutpostManager) EnsureRunning(ctx context.Context, token, tailnetD
 	}
 
 	spec := container.Spec{
-		Name:    proxyOutpostContainerName,
-		Image:   ProxyOutpostImage,
-		Network: "apps-net",
+		Name:     proxyOutpostContainerName,
+		Image:    ProxyOutpostImage,
+		Networks: []string{"apps-net"},
 		Environment: map[string]string{
 			"AUTHENTIK_HOST":         "http://apps-authentik-server:9000",
 			"AUTHENTIK_HOST_BROWSER": "https://bloud." + tailnetDomain,

--- a/services/host-agent/internal/sharing/tailnet_node.go
+++ b/services/host-agent/internal/sharing/tailnet_node.go
@@ -104,9 +104,9 @@ func (m *TailnetNodeManager) EnsureRunning(ctx context.Context, appName string) 
 	}
 
 	spec := container.Spec{
-		Name:    name,
-		Image:   TailscaleImage,
-		Network: "host",
+		Name:     name,
+		Image:    TailscaleImage,
+		Networks: []string{"host"},
 		Environment: map[string]string{
 			"TS_AUTHKEY":      authKey,
 			"TS_HOSTNAME":     appName,

--- a/services/host-agent/internal/sharing/tailnet_node_test.go
+++ b/services/host-agent/internal/sharing/tailnet_node_test.go
@@ -76,7 +76,7 @@ func TestEnsureRunning_CreatesSpecWithServeConfigAndDependsOn(t *testing.T) {
 	spec := rt.Ensured[0]
 	assert.Equal(t, "ts-navidrome", spec.Name)
 	assert.Equal(t, TailscaleImage, spec.Image)
-	assert.Equal(t, "host", spec.Network)
+	assert.Equal(t, []string{"host"}, spec.Networks)
 	assert.Equal(t, "tskey-auth-test", spec.Environment["TS_AUTHKEY"])
 	assert.Equal(t, "navidrome", spec.Environment["TS_HOSTNAME"])
 	assert.Equal(t, "true", spec.Environment["TS_USERSPACE"])


### PR DESCRIPTION
## Problem

Containers defined with a `networks:` list (e.g. Authentik's LDAP outpost on both `authentik-internal` and `apps-net`) were silently collapsed to a single network. The container spec, podman client, and quadlet renderer all only supported one network.

This broke Jellyfin login: the LDAP outpost never joined `apps-net`, so Jellyfin (on `apps-net`) couldn't resolve or bind `apps-authentik-ldap:3389`, and every login returned "Invalid username or password".

## Change

Replace the single `Network` field with a `Networks` list through the whole container stack:

- **`container/runtime.go`** — `Spec.Network` → `Spec.Networks []string`
- **`container/quadlet.go`** — renders one `Network=` line per network, with newline validation
- **`podman/client.go`** — `ContainerConfig.Networks []string`; spec builder attaches all networks (bridge) or uses host nsmode for `["host"]`
- **`orchestrator_containers.go`** — `ContainerSpecFromDef` collects `Network` + `Networks` (deduped)
- **`sharing/*`** — tailnet gateway/node → `["host"]`, proxy outpost → `["apps-net"]`

## Testing

- New regression tests: multi-network quadlet render, newline rejection, podman spec for multi-network/host/default, and `ContainerSpecFromDef` for multi/singular/no-network cases
- Full suite passes (512 Go + 29 app + 28 TS tests)
- Verified live: after deploy, `apps-authentik-ldap` and `apps-authentik-server` join both networks and Jellyfin LDAP login works