### PR TITLE
fix(immich): use REDIS_HOSTNAME instead of REDIS_URL

### DIFF
--- a/apps/immich/metadata.yaml
+++ b/apps/immich/metadata.yaml
@@ -52,7 +52,7 @@ containers:
         container: 2283
     environment:
       DB_URL: "postgres://immich:{{postgresPassword}}@apps-immich-postgres:5432/immich"
-      REDIS_URL: "redis://apps-immich-redis:6379"
+      REDIS_HOSTNAME: apps-immich-redis
       IMMICH_LOG_LEVEL: log
     volumes:
       - source: "{{appDataDir}}/upload"

--- a/docs/compose-app-spec.md
+++ b/docs/compose-app-spec.md
@@ -264,7 +264,7 @@ containers:
         container: 2283
     environment:
       DB_URL: "postgres://postgres:{{postgresPassword}}@apps-immich-postgres:5432/immich"
-      REDIS_URL: "redis://apps-immich-redis:6379"
+      REDIS_HOSTNAME: apps-immich-redis
     volumes:
       - source: "{{appDataDir}}/upload"
         destination: /usr/src/app/upload


### PR DESCRIPTION
## What

The Immich server container uses `REDIS_HOSTNAME` (not `REDIS_URL`) to configure Redis connection. The previous value would cause Immich to fail to connect to Redis on startup.

## Changes

- `apps/immich/metadata.yaml`: Change `REDIS_URL: "redis://apps-immich-redis:6379"` to `REDIS_HOSTNAME: apps-immich-redis`
- `docs/compose-app-spec.md`: Update example to match the corrected env var