### PR TITLE
refactor(cli): introduce executor/host/backend abstraction with Lima backend

### DIFF
--- a/cli/backend/backend.go
+++ b/cli/backend/backend.go
@@ -1,0 +1,19 @@
+// Package backend abstracts provisioning and lifecycle management of runtime
+// environments (Lima VM, native box, etc.).
+package backend
+
+import (
+	"context"
+
+	"codeberg.org/d-buckner/bloud/cli/executor"
+)
+
+// Backend provisions a runtime environment and exposes its Host once ready.
+type Backend interface {
+	// Create ensures the environment exists and is running.
+	Create(ctx context.Context) error
+	// Destroy tears the environment down.
+	Destroy(ctx context.Context) error
+	// Host returns the runtime host for executing commands.
+	Host() executor.Host
+}

--- a/cli/backend/lima.go
+++ b/cli/backend/lima.go
@@ -1,0 +1,97 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"codeberg.org/d-buckner/bloud/cli/executor"
+)
+
+// devRemoteDir is where the host-agent and app data live inside the VM.
+const devRemoteDir = "/var/tmp/bloud-dev-runtime"
+
+// LimaBackend provisions and manages a Lima VM via `limactl`.
+type LimaBackend struct {
+	instance   string
+	projectDir string
+	newCmd     func(ctx context.Context, name string, args ...string) *exec.Cmd
+}
+
+// NewLimaBackend returns a backend that manages the named Lima VM. projectDir
+// is the bloud repo root on the host (mounted into the VM).
+func NewLimaBackend(instance, projectDir string) *LimaBackend {
+	return &LimaBackend{instance: instance, projectDir: projectDir, newCmd: exec.CommandContext}
+}
+
+// Create ensures the Lima VM exists and is running.
+func (b *LimaBackend) Create(ctx context.Context) error {
+	out, err := b.run(ctx, "limactl", "list", "--json")
+	if err != nil {
+		return fmt.Errorf("failed to list Lima VMs: %w", err)
+	}
+
+	if !executor.IsVMNamePresent(out, b.instance) {
+		if _, err := b.run(ctx, "limactl", "create", "--name="+b.instance,
+			filepath.Join(b.projectDir, "dev", "lima.yaml")); err != nil {
+			return fmt.Errorf("failed to create Lima VM: %w", err)
+		}
+	}
+	if !executor.IsVMNameRunning(out, b.instance) {
+		if _, err := b.run(ctx, "limactl", "start", b.instance); err != nil {
+			return fmt.Errorf("failed to start Lima VM: %w", err)
+		}
+	}
+
+	out, err = b.run(ctx, "limactl", "list", "--json")
+	if err != nil {
+		return fmt.Errorf("failed to verify Lima VM: %w", err)
+	}
+	if !executor.IsVMNameRunning(out, b.instance) {
+		return fmt.Errorf("Lima VM %q did not become ready", b.instance)
+	}
+	return nil
+}
+
+// Destroy deletes the Lima VM.
+func (b *LimaBackend) Destroy(ctx context.Context) error {
+	if _, err := b.run(ctx, "limactl", "delete", "--force", b.instance); err != nil {
+		return fmt.Errorf("failed to delete Lima VM: %w", err)
+	}
+	return nil
+}
+
+// Host returns the runtime host backed by the Lima VM.
+func (b *LimaBackend) Host() executor.Host {
+	return executor.NewSSHHost(
+		b.instance,
+		executor.NewSSHExecutor(b.instance),
+		&executor.LocalExecutor{},
+		map[string]string{
+			"host-agent": "3000",
+			"postgres":   "5432",
+			"traefik":    "8080",
+			"jellyfin":   "8096",
+			"authentik":  "9000",
+		},
+		executor.DataDirs{
+			HostAgentDir: devRemoteDir + "/host-agent",
+			DataDir:      devRemoteDir + "/data",
+			AppsDir:      filepath.Join(b.projectDir, "apps"),
+		},
+	)
+}
+
+func (b *LimaBackend) run(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := b.newCmd(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.String(), fmt.Errorf("%s: %s: %w", name, strings.TrimSpace(stderr.String()), err)
+	}
+	return stdout.String(), nil
+}

--- a/cli/backend/lima_test.go
+++ b/cli/backend/lima_test.go
@@ -1,0 +1,150 @@
+package backend
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func fakeLimaBackend(t *testing.T, recorded *[][]string, listOutputs []string) *LimaBackend {
+	t.Helper()
+	var call int
+	return &LimaBackend{
+		instance:   "bloud-dev",
+		projectDir: "/repo",
+		newCmd: func(_ context.Context, name string, args ...string) *exec.Cmd {
+			*recorded = append(*recorded, append([]string{name}, args...))
+			if name == "limactl" && len(args) == 2 && args[0] == "list" && args[1] == "--json" {
+				f, err := os.CreateTemp(t.TempDir(), "limactl-list-*")
+				if err != nil {
+					return exec.Command("false")
+				}
+				if len(listOutputs) > 0 {
+					idx := call
+					if idx >= len(listOutputs) {
+						idx = len(listOutputs) - 1
+					}
+					f.WriteString(listOutputs[idx])
+				}
+				f.Close()
+				call++
+				return exec.Command("cat", f.Name())
+			}
+			return exec.Command("true")
+		},
+	}
+}
+
+func TestLimaBackendCreateAlreadyRunning(t *testing.T) {
+	var recorded [][]string
+	b := fakeLimaBackend(t, &recorded, []string{`{"name":"bloud-dev","status":"Running"}` + "\n"})
+	if err := b.Create(context.Background()); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	want := [][]string{{"limactl", "list", "--json"}, {"limactl", "list", "--json"}}
+	if !reflect.DeepEqual(recorded, want) {
+		t.Fatalf("invocations = %v, want %v", recorded, want)
+	}
+}
+
+func TestLimaBackendCreateStoppedStartsVM(t *testing.T) {
+	var recorded [][]string
+	b := fakeLimaBackend(t, &recorded, []string{
+		`{"name":"bloud-dev","status":"Stopped"}` + "\n",
+		`{"name":"bloud-dev","status":"Running"}` + "\n",
+	})
+	if err := b.Create(context.Background()); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	want := [][]string{
+		{"limactl", "list", "--json"},
+		{"limactl", "start", "bloud-dev"},
+		{"limactl", "list", "--json"},
+	}
+	if !reflect.DeepEqual(recorded, want) {
+		t.Fatalf("invocations = %v, want %v", recorded, want)
+	}
+}
+
+func TestLimaBackendCreateMissingCreatesVM(t *testing.T) {
+	var recorded [][]string
+	b := fakeLimaBackend(t, &recorded, []string{
+		"",
+		`{"name":"bloud-dev","status":"Running"}` + "\n",
+	})
+	if err := b.Create(context.Background()); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	want := [][]string{
+		{"limactl", "list", "--json"},
+		{"limactl", "create", "--name=bloud-dev", "/repo/dev/lima.yaml"},
+		{"limactl", "start", "bloud-dev"},
+		{"limactl", "list", "--json"},
+	}
+	if !reflect.DeepEqual(recorded, want) {
+		t.Fatalf("invocations = %v, want %v", recorded, want)
+	}
+}
+
+func TestLimaBackendCreateVerifyFails(t *testing.T) {
+	var recorded [][]string
+	b := fakeLimaBackend(t, &recorded, []string{
+		`{"name":"bloud-dev","status":"Running"}` + "\n",
+		`{"name":"bloud-dev","status":"Stopped"}` + "\n",
+	})
+	err := b.Create(context.Background())
+	if err == nil {
+		t.Fatal("Create() error = nil, want non-nil")
+	}
+}
+
+func TestLimaBackendCreateListFails(t *testing.T) {
+	var recorded [][]string
+	b := fakeLimaBackend(t, &recorded, nil)
+	b.newCmd = func(_ context.Context, name string, args ...string) *exec.Cmd {
+		recorded = append(recorded, append([]string{name}, args...))
+		return exec.Command("sh", "-c", "exit 1")
+	}
+	if err := b.Create(context.Background()); err == nil {
+		t.Fatal("Create() error = nil, want non-nil")
+	}
+}
+
+func TestLimaBackendDestroy(t *testing.T) {
+	var recorded [][]string
+	b := fakeLimaBackend(t, &recorded, nil)
+	if err := b.Destroy(context.Background()); err != nil {
+		t.Fatalf("Destroy() error = %v", err)
+	}
+	want := [][]string{{"limactl", "delete", "--force", "bloud-dev"}}
+	if !reflect.DeepEqual(recorded, want) {
+		t.Fatalf("invocations = %v, want %v", recorded, want)
+	}
+}
+
+func TestLimaBackendHost(t *testing.T) {
+	var recorded [][]string
+	b := fakeLimaBackend(t, &recorded, nil)
+	h := b.Host()
+	if h.Executor() == nil {
+		t.Error("Host().Executor() = nil")
+	}
+	if got := h.Ports()["traefik"]; got != "8080" {
+		t.Errorf("Ports()[traefik] = %q, want 8080", got)
+	}
+	if got := h.Ports()["host-agent"]; got != "3000" {
+		t.Errorf("Ports()[host-agent] = %q, want 3000", got)
+	}
+	dirs := h.DataDirs()
+	if dirs.HostAgentDir != "/var/tmp/bloud-dev-runtime/host-agent" {
+		t.Errorf("HostAgentDir = %q, want /var/tmp/bloud-dev-runtime/host-agent", dirs.HostAgentDir)
+	}
+	if dirs.DataDir != "/var/tmp/bloud-dev-runtime/data" {
+		t.Errorf("DataDir = %q, want /var/tmp/bloud-dev-runtime/data", dirs.DataDir)
+	}
+	if dirs.AppsDir != "/repo/apps" {
+		t.Errorf("AppsDir = %q, want /repo/apps", dirs.AppsDir)
+	}
+}

--- a/cli/dev.go
+++ b/cli/dev.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -8,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 
+	"codeberg.org/d-buckner/bloud/cli/backend"
+	"codeberg.org/d-buckner/bloud/cli/executor"
 	"codeberg.org/d-buckner/bloud/cli/vm"
 )
 
@@ -16,17 +19,13 @@ func localExec(name string, args ...string) *exec.Cmd {
 	return exec.Command(name, args...)
 }
 
-// runForeground runs an interactive command, treating a signal-based exit
-// (e.g. Ctrl-C) as a clean stop rather than a failure.
-func runForeground(cmd *exec.Cmd) error {
-	err := cmd.Run()
-	if err == nil {
-		return nil
-	}
+// isSignalExit reports whether err came from a process killed by a signal
+// (e.g. Ctrl-C), which interactive commands treat as a clean stop.
+func isSignalExit(err error) bool {
 	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == -1 {
-		return nil
+		return true
 	}
-	return err
+	return false
 }
 
 func getProjectRoot() (string, error) {
@@ -78,12 +77,16 @@ func cmdStart() int {
 
 func cmdStop() int {
 	lima := limaInstance()
+	bk, err := devBackend()
+	if err != nil {
+		errorf("Could not set up backend: %v", err)
+		return 1
+	}
 	log("Stopping host-agent on " + lima)
-	cmd := exec.Command("limactl", "shell", lima, "bash", "-c",
-		`pkill -f 'host-agent$' 2>/dev/null; systemctl --user stop apps-*.service 2>/dev/null; true`)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	err = bk.Host().Executor().RunStream(context.Background(), executor.RunSpec{
+		Command: `pkill -f 'host-agent$' 2>/dev/null; systemctl --user stop apps-*.service 2>/dev/null; true`,
+	}, os.Stdout, os.Stderr)
+	if err != nil && !isSignalExit(err) {
 		errorf("Failed to stop host-agent: %v", err)
 		return 1
 	}
@@ -96,23 +99,28 @@ func cmdStatus() int {
 	fmt.Println()
 	fmt.Printf("  Lima VM:  %s\n", lima)
 
+	bk, err := devBackend()
+	if err != nil {
+		errorf("Could not set up backend: %v", err)
+		return 1
+	}
+	host := bk.Host()
+
 	// Check if VM is running
-	out, err := exec.Command("limactl", "list", "--json").Output()
-	if err == nil {
-		if strings.Contains(string(out), `"name":"`+lima+`"`) && strings.Contains(string(out), `"status":"Running"`) {
-			fmt.Printf("  VM status: %sRunning%s\n", colorGreen, colorReset)
-		} else {
-			fmt.Printf("  VM status: %sStopped%s\n", colorRed, colorReset)
-			fmt.Println()
-			fmt.Println("  Start the VM with: limactl start " + lima)
-			return 0
-		}
+	if host.Ready() {
+		fmt.Printf("  VM status: %sRunning%s\n", colorGreen, colorReset)
+	} else {
+		fmt.Printf("  VM status: %sStopped%s\n", colorRed, colorReset)
+		fmt.Println()
+		fmt.Println("  Start the VM with: limactl start " + lima)
+		return 0
 	}
 
 	// Check host-agent
-	curl := exec.Command("limactl", "shell", lima, "bash", "-c",
-		"curl -sf http://localhost:3000/api/health 2>/dev/null && echo ok || echo down")
-	if o, err := curl.Output(); err == nil && strings.TrimSpace(string(o)) == "ok" {
+	res, err := host.Executor().Run(context.Background(), executor.RunSpec{
+		Command: `curl -sf http://localhost:3000/api/health 2>/dev/null && echo ok || echo down`,
+	})
+	if err == nil && strings.Contains(res.Stdout, "ok") {
 		fmt.Printf("  Host agent: %sRunning%s (localhost:3000)\n", colorGreen, colorReset)
 	} else {
 		fmt.Printf("  Host agent: %sNot running%s\n", colorRed, colorReset)
@@ -126,12 +134,16 @@ func cmdStatus() int {
 
 func cmdLogs() int {
 	lima := limaInstance()
+	bk, err := devBackend()
+	if err != nil {
+		errorf("Could not set up backend: %v", err)
+		return 1
+	}
 	log("Streaming host-agent logs from " + lima + " (Ctrl-C to stop)...")
-	cmd := exec.Command("limactl", "shell", lima, "bash", "-c",
-		"journalctl --user -u host-agent -f 2>/dev/null || journalctl -f 2>/dev/null")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := runForeground(cmd); err != nil {
+	err = bk.Host().Executor().RunStream(context.Background(), executor.RunSpec{
+		Command: `journalctl --user -u host-agent -f 2>/dev/null || journalctl -f 2>/dev/null`,
+	}, os.Stdout, os.Stderr)
+	if err != nil && !isSignalExit(err) {
 		errorf("Failed to stream logs: %v", err)
 		return 1
 	}
@@ -140,12 +152,18 @@ func cmdLogs() int {
 
 func cmdAttach() int {
 	lima := limaInstance()
+	bk, err := devBackend()
+	if err != nil {
+		errorf("Could not set up backend: %v", err)
+		return 1
+	}
+	sshex, ok := bk.Host().Executor().(*executor.SSHExecutor)
+	if !ok {
+		errorf("Backend host does not support interactive shells")
+		return 1
+	}
 	log("Opening shell on " + lima + " (type 'exit' to leave)...")
-	cmd := exec.Command("limactl", "shell", lima)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
-	if err := runForeground(cmd); err != nil {
+	if err := sshex.InteractiveShell(context.Background(), os.Stdout, os.Stderr, os.Stdin); err != nil && !isSignalExit(err) {
 		errorf("Failed to open shell on "+lima+": %v", err)
 		return 1
 	}
@@ -153,20 +171,22 @@ func cmdAttach() int {
 }
 
 func cmdShell(args []string) int {
-	lima := limaInstance()
 	if len(args) == 0 {
 		return cmdAttach()
 	}
+	bk, err := devBackend()
+	if err != nil {
+		errorf("Could not set up backend: %v", err)
+		return 1
+	}
 	command := strings.Join(args, " ")
-	if err := vm.LocalInteractive(fmt.Sprintf("limactl shell %s bash -c %s", lima, shellQuoteArg(command))); err != nil {
+	if err := bk.Host().Executor().RunStream(context.Background(), executor.RunSpec{
+		Command: command,
+	}, os.Stdout, os.Stderr); err != nil && !isSignalExit(err) {
 		errorf("Command failed: %v", err)
 		return 1
 	}
 	return 0
-}
-
-func shellQuoteArg(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
 func cmdRebuild() int {
@@ -177,12 +197,15 @@ func cmdRebuild() int {
 }
 
 func cmdServices() int {
-	lima := limaInstance()
-	cmd := exec.Command("limactl", "shell", lima, "bash", "-c",
-		"systemctl --user list-units 'apps-*' --all --no-pager")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	bk, err := devBackend()
+	if err != nil {
+		errorf("Could not set up backend: %v", err)
+		return 1
+	}
+	err = bk.Host().Executor().RunStream(context.Background(), executor.RunSpec{
+		Command: `systemctl --user list-units 'apps-*' --all --no-pager`,
+	}, os.Stdout, os.Stderr)
+	if err != nil && !isSignalExit(err) {
 		errorf("Failed to list services: %v", err)
 		return 1
 	}
@@ -191,6 +214,13 @@ func cmdServices() int {
 
 func cmdReset() int {
 	lima := limaInstance()
+	bk, err := devBackend()
+	if err != nil {
+		errorf("Could not set up backend: %v", err)
+		return 1
+	}
+	host := bk.Host()
+	ex := host.Executor()
 
 	fmt.Printf("This will stop all services and wipe all app data in '%s'.\n", lima)
 	fmt.Printf("The VM itself is kept — only data, containers, and the database are removed.\n")
@@ -204,25 +234,22 @@ func cmdReset() int {
 
 	// 1. Kill host-agent
 	log("Stopping host-agent")
-	cmd := exec.Command("limactl", "shell", lima, "bash", "-c",
-		`pkill -f 'host-agent$' 2>/dev/null; true`)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := ex.RunStream(context.Background(), executor.RunSpec{
+		Command: `pkill -f 'host-agent$' 2>/dev/null; true`,
+	}, os.Stdout, os.Stderr); err != nil {
 		errorf("Failed to stop host-agent: %v", err)
 		return 1
 	}
 
 	// 2. Remove all containers
 	log("Removing containers")
-	cmd = exec.Command("limactl", "shell", lima, "bash", "-c", `
+	if err := ex.RunStream(context.Background(), executor.RunSpec{
+		Command: `
 set -e
 podman rm -f $(podman ps -aq) 2>/dev/null || true
 podman system prune -f 2>/dev/null || true
-`)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+`,
+	}, os.Stdout, os.Stderr); err != nil {
 		errorf("Failed to stop services: %v", err)
 		return 1
 	}
@@ -230,15 +257,14 @@ podman system prune -f 2>/dev/null || true
 	// 3. Wipe data directories and database
 	// Use podman unshare for dirs with container-owned files (e.g. postgres)
 	log("Wiping data")
-	cmd = exec.Command("limactl", "shell", lima, "bash", "-c", `
+	if err := ex.RunStream(context.Background(), executor.RunSpec{
+		Command: `
 set -e
 podman unshare rm -rf "$HOME/.local/share/bloud"
 podman unshare rm -rf /var/tmp/bloud-dev-runtime/data
 rm -f /var/tmp/bloud-dev-runtime/bloud.db
-`)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+`,
+	}, os.Stdout, os.Stderr); err != nil {
 		errorf("Failed to wipe data: %v", err)
 		return 1
 	}
@@ -257,11 +283,13 @@ func cmdDestroy() int {
 		fmt.Println("Aborted.")
 		return 0
 	}
+	bk, err := devBackend()
+	if err != nil {
+		errorf("Could not set up backend: %v", err)
+		return 1
+	}
 	log("Deleting " + lima + "...")
-	cmd := exec.Command("limactl", "delete", "--force", lima)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := bk.Destroy(context.Background()); err != nil {
 		errorf("Failed to delete VM: %v", err)
 		return 1
 	}
@@ -315,7 +343,14 @@ func installApp(apiPort int, appName string) int {
 	return 0
 }
 
-const devRemoteDir = "/var/tmp/bloud-dev-runtime"
+// devBackend builds the Lima backend for the current project.
+func devBackend() (*backend.LimaBackend, error) {
+	root, err := getProjectRoot()
+	if err != nil {
+		return nil, err
+	}
+	return backend.NewLimaBackend(limaInstance(), root), nil
+}
 
 func cmdDev() int {
 	root, err := getProjectRoot()
@@ -324,10 +359,10 @@ func cmdDev() int {
 		return 1
 	}
 
-	lima := os.Getenv("BLOUD_E2E_LIMA_INSTANCE")
-	if lima == "" {
-		lima = "bloud-dev"
-	}
+	bk := backend.NewLimaBackend(limaInstance(), root)
+	host := bk.Host()
+	ex := host.Executor()
+	dirs := host.DataDirs()
 	goarch := runtime.GOARCH
 
 	// Clean slate: remove managed containers before the host-agent takes over.
@@ -340,7 +375,9 @@ func cmdDev() int {
 	// orchestrator from recreating authentik (podman refuses to remove a container
 	// that still has dependent containers).
 	log("Stopping managed app containers")
-	if err := limaRun(lima, `podman rm -f bloud-dev-postgres bloud-dev-redis apps-traefik dev_authentik-worker_1 dev_authentik-proxy_1 apps-authentik-ldap apps-authentik-server 2>/dev/null; podman ps -a --filter label=io.bloud.managed=true -q | xargs -r podman rm -f -t 2 2>/dev/null; true`); err != nil {
+	if err := ex.RunStream(context.Background(), executor.RunSpec{
+		Command: `podman rm -f bloud-dev-postgres bloud-dev-redis apps-traefik dev_authentik-worker_1 dev_authentik-proxy_1 apps-authentik-ldap apps-authentik-server 2>/dev/null; podman ps -a --filter label=io.bloud.managed=true -q | xargs -r podman rm -f -t 2 2>/dev/null; true`,
+	}, os.Stdout, os.Stderr); err != nil {
 		errorf("Failed to stop managed app containers: %v", err)
 		return 1
 	}
@@ -350,7 +387,9 @@ func cmdDev() int {
 	// Redis on localhost:6379 (sessions). Compose recreates containers whose
 	// config changed (e.g. redis gaining the published 6379 port).
 	log("Ensuring shared infra (postgres, redis)")
-	if err := limaRun(lima, fmt.Sprintf("cd %s/dev && podman-compose up -d postgres redis 2>&1", root)); err != nil {
+	if err := ex.RunStream(context.Background(), executor.RunSpec{
+		Command: fmt.Sprintf("cd %s/dev && podman-compose up -d postgres redis 2>&1", root),
+	}, os.Stdout, os.Stderr); err != nil {
 		errorf("Failed to start shared infra: %v", err)
 		return 1
 	}
@@ -389,20 +428,21 @@ func cmdDev() int {
 	}
 
 	// Deploy
-	log("Deploying to " + lima + ":" + devRemoteDir)
-	if err := limaRun(lima, "mkdir -p "+devRemoteDir+"/host-agent"); err != nil {
+	log("Deploying to " + dirs.HostAgentDir)
+	if err := ex.RunStream(context.Background(), executor.RunSpec{
+		Command: "mkdir -p " + dirs.HostAgentDir,
+	}, os.Stdout, os.Stderr); err != nil {
 		errorf("Failed to create remote dir: %v", err)
 		return 1
 	}
-	copyCmd := exec.Command("limactl", "copy", binaryPath, lima+":"+devRemoteDir+"/host-agent/host-agent")
-	copyCmd.Stdout = os.Stdout
-	copyCmd.Stderr = os.Stderr
-	if err := copyCmd.Run(); err != nil {
+	if err := ex.CopyTo(context.Background(), binaryPath, dirs.HostAgentDir+"/host-agent"); err != nil {
 		errorf("Failed to copy binary: %v", err)
 		return 1
 	}
 
-	if err := limaRun(lima, "chmod 755 "+devRemoteDir+"/host-agent/host-agent"); err != nil {
+	if err := ex.RunStream(context.Background(), executor.RunSpec{
+		Command: "chmod 755 " + dirs.HostAgentDir + "/host-agent",
+	}, os.Stdout, os.Stderr); err != nil {
 		errorf("Failed to chmod binary: %v", err)
 		return 1
 	}
@@ -410,18 +450,19 @@ func cmdDev() int {
 	// Deploy frontend build to VM
 	webBuildDir := filepath.Join(webDir, "build")
 	if _, err := os.Stat(webBuildDir); err == nil {
-		if err := limaRun(lima, "rm -rf "+devRemoteDir+"/host-agent/web/build"); err != nil {
+		if err := ex.RunStream(context.Background(), executor.RunSpec{
+			Command: "rm -rf " + dirs.HostAgentDir + "/web/build",
+		}, os.Stdout, os.Stderr); err != nil {
 			errorf("Failed to clean remote web dir: %v", err)
 			return 1
 		}
-		if err := limaRun(lima, "mkdir -p "+devRemoteDir+"/host-agent/web"); err != nil {
+		if err := ex.RunStream(context.Background(), executor.RunSpec{
+			Command: "mkdir -p " + dirs.HostAgentDir + "/web",
+		}, os.Stdout, os.Stderr); err != nil {
 			errorf("Failed to create remote web dir: %v", err)
 			return 1
 		}
-		cpCmd := exec.Command("limactl", "copy", "-r", webBuildDir, lima+":"+devRemoteDir+"/host-agent/web/build")
-		cpCmd.Stdout = os.Stdout
-		cpCmd.Stderr = os.Stderr
-		if err := cpCmd.Run(); err != nil {
+		if err := ex.CopyTo(context.Background(), webBuildDir, dirs.HostAgentDir+"/web/build"); err != nil {
 			errorf("Failed to copy frontend build: %v", err)
 			return 1
 		}
@@ -429,41 +470,29 @@ func cmdDev() int {
 	}
 
 	// Kill anything on port 3000 and any previous dev host-agent
-	if err := limaRun(lima, `fuser -k 3000/tcp 2>/dev/null || true; pkill -f '`+devRemoteDir+`/host-agent/host-a[g]ent' 2>/dev/null || true; sleep 0.5`); err != nil {
+	if err := ex.RunStream(context.Background(), executor.RunSpec{
+		Command: `fuser -k 3000/tcp 2>/dev/null || true; pkill -f '` + dirs.HostAgentDir + `/host-agent/host-a[g]ent' 2>/dev/null || true; sleep 0.5`,
+	}, os.Stdout, os.Stderr); err != nil {
 		errorf("Failed to stop previous host-agent: %v", err)
 		return 1
 	}
 
-	// Build the env and exec command
-	appsDir := filepath.Join(root, "apps")
-
-	remoteScript := fmt.Sprintf(
-		`unset DATABASE_URL BLOUD_REDIS_ADDR; `+
-			`export BLOUD_DATA_DIR=%s/data `+
-			`BLOUD_APPS_DIR=%s `+
-			`BLOUD_TRAEFIK_DYNAMIC_DIR=%s/data/traefik/dynamic; `+
-			`cd %s/host-agent && exec ./host-agent`,
-		devRemoteDir, appsDir, devRemoteDir, devRemoteDir,
-	)
-
 	// Run foreground
 	log("Starting host-agent (Ctrl-C to stop)")
-	runCmd := exec.Command("limactl", "shell", "--start", lima, "bash", "-c", remoteScript)
-	runCmd.Stdout = os.Stdout
-	runCmd.Stderr = os.Stderr
-	runCmd.Stdin = os.Stdin
-	if err := runForeground(runCmd); err != nil {
-		errorf("host-agent exited: %v", err)
+	runErr := ex.RunStream(context.Background(), executor.RunSpec{
+		Command: "unset DATABASE_URL BLOUD_REDIS_ADDR; exec ./host-agent",
+		Dir:     dirs.HostAgentDir,
+		Env: map[string]string{
+			"BLOUD_DATA_DIR":           dirs.DataDir,
+			"BLOUD_APPS_DIR":           dirs.AppsDir,
+			"BLOUD_TRAEFIK_DYNAMIC_DIR": dirs.DataDir + "/traefik/dynamic",
+		},
+	}, os.Stdout, os.Stderr)
+	if runErr != nil && !isSignalExit(runErr) {
+		errorf("host-agent exited: %v", runErr)
 		return 1
 	}
 	return 0
-}
-
-func limaRun(instance, script string) error {
-	cmd := exec.Command("limactl", "shell", "--start", instance, "bash", "-c", script)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
 }
 
 // uninstallApp calls the host-agent API to uninstall an app

--- a/cli/executor/executor.go
+++ b/cli/executor/executor.go
@@ -1,0 +1,37 @@
+// Package executor abstracts command execution and file transfer to a
+// runtime host (local machine, SSH/Lima VM, etc.).
+package executor
+
+import (
+	"context"
+	"io"
+)
+
+// Executor runs commands and transfers files to/from a runtime host.
+type Executor interface {
+	// Run executes a command and captures its output.
+	Run(ctx context.Context, spec RunSpec) (ExecResult, error)
+	// RunStream executes a command, streaming stdout/stderr to the given writers.
+	RunStream(ctx context.Context, spec RunSpec, stdout, stderr io.Writer) error
+	// CopyTo uploads a local file or directory to a remote path.
+	CopyTo(ctx context.Context, from, to string) error
+	// CopyFrom downloads a remote file or directory to a local path.
+	CopyFrom(ctx context.Context, from, to string) error
+}
+
+// RunSpec describes a single command execution.
+type RunSpec struct {
+	Command string
+	Args    []string
+	Env     map[string]string
+	Stdin   io.Reader
+	Dir     string
+	AsRoot  bool
+}
+
+// ExecResult captures the outcome of a Run call.
+type ExecResult struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}

--- a/cli/executor/executor_test.go
+++ b/cli/executor/executor_test.go
@@ -1,0 +1,135 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLocalRunSuccess(t *testing.T) {
+	res, err := (&LocalExecutor{}).Run(context.Background(), RunSpec{
+		Command: "echo",
+		Args:    []string{"hello"},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0", res.ExitCode)
+	}
+	if res.Stdout != "hello\n" {
+		t.Fatalf("Stdout = %q, want %q", res.Stdout, "hello\n")
+	}
+}
+
+func TestLocalRunFailure(t *testing.T) {
+	res, err := (&LocalExecutor{}).Run(context.Background(), RunSpec{
+		Command: "sh",
+		Args:    []string{"-c", "exit 3"},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want non-nil")
+	}
+	if res.ExitCode != 3 {
+		t.Fatalf("ExitCode = %d, want 3", res.ExitCode)
+	}
+}
+
+func TestLocalRunEnv(t *testing.T) {
+	res, err := (&LocalExecutor{}).Run(context.Background(), RunSpec{
+		Command: "sh",
+		Args:    []string{"-c", `printf '%s' "$FOO"`},
+		Env:     map[string]string{"FOO": "bar"},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if res.Stdout != "bar" {
+		t.Fatalf("Stdout = %q, want %q", res.Stdout, "bar")
+	}
+}
+
+func TestLocalRunStdin(t *testing.T) {
+	res, err := (&LocalExecutor{}).Run(context.Background(), RunSpec{
+		Command: "cat",
+		Stdin:   strings.NewReader("payload"),
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if res.Stdout != "payload" {
+		t.Fatalf("Stdout = %q, want %q", res.Stdout, "payload")
+	}
+}
+
+func TestLocalRunDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "marker"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	res, err := (&LocalExecutor{}).Run(context.Background(), RunSpec{
+		Command: "ls",
+		Dir:     dir,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(res.Stdout, "marker") {
+		t.Fatalf("Stdout = %q, want it to contain %q", res.Stdout, "marker")
+	}
+}
+
+func TestLocalCopyTo(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src.txt")
+	dst := filepath.Join(t.TempDir(), "dst.txt")
+	if err := os.WriteFile(src, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&LocalExecutor{}).CopyTo(context.Background(), src, dst); err != nil {
+		t.Fatalf("CopyTo() error = %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading dst: %v", err)
+	}
+	if string(got) != "data" {
+		t.Fatalf("dst = %q, want %q", string(got), "data")
+	}
+}
+
+func TestLocalCopyFrom(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src.txt")
+	dst := filepath.Join(t.TempDir(), "dst.txt")
+	if err := os.WriteFile(src, []byte("payload"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&LocalExecutor{}).CopyFrom(context.Background(), src, dst); err != nil {
+		t.Fatalf("CopyFrom() error = %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading dst: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("dst = %q, want %q", string(got), "payload")
+	}
+}
+
+func TestLocalRunStream(t *testing.T) {
+	var stdout, stderr strings.Builder
+	err := (&LocalExecutor{}).RunStream(context.Background(),
+		RunSpec{Command: "sh", Args: []string{"-c", `printf 'out'; printf 'err' >&2`}},
+		&stdout, &stderr,
+	)
+	if err != nil {
+		t.Fatalf("RunStream() error = %v", err)
+	}
+	if stdout.String() != "out" {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), "out")
+	}
+	if stderr.String() != "err" {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), "err")
+	}
+}

--- a/cli/executor/host.go
+++ b/cli/executor/host.go
@@ -1,0 +1,92 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// Host describes a runtime environment the CLI can execute against.
+type Host interface {
+	// Executor returns the executor used to run commands on the host.
+	Executor() Executor
+	// Ports maps logical service names to guest port numbers.
+	Ports() map[string]string
+	// DataDirs returns the runtime directory layout on the host.
+	DataDirs() DataDirs
+	// Ready reports whether the host is running and usable.
+	Ready() bool
+}
+
+// DataDirs describes where bloud artifacts live on a runtime host.
+type DataDirs struct {
+	HostAgentDir string // where the host-agent binary lives
+	DataDir      string // app data, secrets, traefik config
+	AppsDir      string // mounted apps directory
+}
+
+// SSHHost is a Host running on a Lima VM, reached through an SSHExecutor.
+type SSHHost struct {
+	instance string
+	remote   Executor
+	local    Executor
+	ports    map[string]string
+	dataDirs DataDirs
+}
+
+// NewSSHHost returns a Host backed by a Lima VM. remote executes inside the
+// VM; local executes on the machine running the CLI (used for VM status checks).
+func NewSSHHost(instance string, remote, local Executor, ports map[string]string, dataDirs DataDirs) *SSHHost {
+	return &SSHHost{instance: instance, remote: remote, local: local, ports: ports, dataDirs: dataDirs}
+}
+
+// Executor returns the executor that runs commands inside the VM.
+func (h *SSHHost) Executor() Executor { return h.remote }
+
+// Ports returns the host-agent service port map.
+func (h *SSHHost) Ports() map[string]string { return h.ports }
+
+// DataDirs returns the runtime directory layout inside the VM.
+func (h *SSHHost) DataDirs() DataDirs { return h.dataDirs }
+
+// Ready reports whether the Lima VM is running.
+func (h *SSHHost) Ready() bool {
+	res, err := h.local.Run(context.Background(), RunSpec{
+		Command: "limactl",
+		Args:    []string{"list", "--json"},
+	})
+	if err != nil {
+		return false
+	}
+	return IsVMNameRunning(res.Stdout, h.instance)
+}
+
+// IsVMNameRunning reports whether limactl list --json output shows name Running.
+func IsVMNameRunning(out, name string) bool {
+	return vmStatus(out, name) == "Running"
+}
+
+// IsVMNamePresent reports whether limactl list --json output lists name at all.
+func IsVMNamePresent(out, name string) bool {
+	return vmStatus(out, name) != ""
+}
+
+func vmStatus(out, name string) string {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var vm struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		}
+		if json.Unmarshal([]byte(line), &vm) != nil {
+			continue
+		}
+		if vm.Name == name {
+			return vm.Status
+		}
+	}
+	return ""
+}

--- a/cli/executor/local.go
+++ b/cli/executor/local.go
@@ -1,0 +1,95 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// LocalExecutor runs commands on the local machine.
+type LocalExecutor struct{}
+
+// Run executes a command locally, capturing stdout and stderr.
+func (e *LocalExecutor) Run(ctx context.Context, spec RunSpec) (ExecResult, error) {
+	cmd := buildLocalCommand(ctx, spec)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return result(stdout.String(), stderr.String(), err)
+}
+
+// RunStream executes a command locally, streaming output to the writers.
+func (e *LocalExecutor) RunStream(ctx context.Context, spec RunSpec, stdout, stderr io.Writer) error {
+	cmd := buildLocalCommand(ctx, spec)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+// CopyTo copies a local file to another local path.
+func (e *LocalExecutor) CopyTo(_ context.Context, from, to string) error {
+	return copyFile(from, to)
+}
+
+// CopyFrom copies a local file from another local path.
+func (e *LocalExecutor) CopyFrom(_ context.Context, from, to string) error {
+	return copyFile(from, to)
+}
+
+func buildLocalCommand(ctx context.Context, spec RunSpec) *exec.Cmd {
+	name, args := spec.Command, spec.Args
+	if spec.AsRoot {
+		name, args = "sudo", append([]string{spec.Command}, spec.Args...)
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	if len(spec.Env) > 0 {
+		cmd.Env = append(os.Environ(), envSlice(spec.Env)...)
+	}
+	cmd.Dir = spec.Dir
+	cmd.Stdin = spec.Stdin
+	return cmd
+}
+
+// result normalizes the outcome of cmd.Run() into an ExecResult.
+func result(stdout, stderr string, err error) (ExecResult, error) {
+	res := ExecResult{Stdout: stdout, Stderr: stderr}
+	res.ExitCode = 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			res.ExitCode = exitErr.ExitCode()
+		} else {
+			res.ExitCode = -1
+		}
+	}
+	return res, err
+}
+
+func envSlice(env map[string]string) []string {
+	var out []string
+	for k, v := range env {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+func copyFile(from, to string) error {
+	in, err := os.Open(from)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", from, err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(to)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", to, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return fmt.Errorf("copy %s -> %s: %w", from, to, err)
+	}
+	return out.Close()
+}

--- a/cli/executor/ssh.go
+++ b/cli/executor/ssh.go
@@ -1,0 +1,119 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// SSHExecutor runs commands and transfers files to a Lima VM via `limactl`.
+type SSHExecutor struct {
+	instance string
+	newCmd   func(ctx context.Context, name string, args ...string) *exec.Cmd
+}
+
+// NewSSHExecutor returns an executor that targets the given Lima instance.
+func NewSSHExecutor(instance string) *SSHExecutor {
+	return &SSHExecutor{instance: instance, newCmd: exec.CommandContext}
+}
+
+// Run executes a command inside the VM, capturing stdout and stderr.
+func (e *SSHExecutor) Run(ctx context.Context, spec RunSpec) (ExecResult, error) {
+	cmd := e.buildShellCommand(ctx, spec)
+	cmd.Stdin = spec.Stdin
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return result(stdout.String(), stderr.String(), err)
+}
+
+// RunStream executes a command inside the VM, streaming output to the writers.
+func (e *SSHExecutor) RunStream(ctx context.Context, spec RunSpec, stdout, stderr io.Writer) error {
+	cmd := e.buildShellCommand(ctx, spec)
+	if spec.Stdin != nil {
+		cmd.Stdin = spec.Stdin
+	} else {
+		cmd.Stdin = os.Stdin
+	}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+// InteractiveShell opens a login shell on the VM with the terminal attached.
+func (e *SSHExecutor) InteractiveShell(ctx context.Context, stdout, stderr io.Writer, stdin io.Reader) error {
+	cmd := e.newCmd(ctx, "limactl", "shell", e.instance)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+// CopyTo uploads a local file or directory into the VM. Directories are copied recursively.
+func (e *SSHExecutor) CopyTo(ctx context.Context, from, to string) error {
+	args := []string{"copy"}
+	if isDirectory(from) {
+		args = append(args, "-r")
+	}
+	args = append(args, from, e.instance+":"+to)
+	cmd := e.newCmd(ctx, "limactl", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// CopyFrom downloads a file or directory from the VM to a local path.
+func (e *SSHExecutor) CopyFrom(ctx context.Context, from, to string) error {
+	cmd := e.newCmd(ctx, "limactl", "copy", e.instance+":"+from, to)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (e *SSHExecutor) buildShellCommand(ctx context.Context, spec RunSpec) *exec.Cmd {
+	return e.newCmd(ctx, "limactl", "shell", "--start", e.instance, "bash", "-c", BuildRemoteScript(spec))
+}
+
+// BuildRemoteScript renders a RunSpec into a bash script executed inside the VM.
+// Env vars are exported in sorted order for deterministic output.
+func BuildRemoteScript(spec RunSpec) string {
+	var b strings.Builder
+	for _, k := range sortedEnvKeys(spec.Env) {
+		fmt.Fprintf(&b, "export %s=%s; ", k, shellQuote(spec.Env[k]))
+	}
+	if spec.Dir != "" {
+		fmt.Fprintf(&b, "cd %s; ", shellQuote(spec.Dir))
+	}
+	if spec.AsRoot {
+		b.WriteString("sudo ")
+	}
+	b.WriteString(spec.Command)
+	if len(spec.Args) > 0 {
+		b.WriteString(" " + strings.Join(spec.Args, " "))
+	}
+	return b.String()
+}
+
+func sortedEnvKeys(env map[string]string) []string {
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+func isDirectory(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/cli/executor/ssh_test.go
+++ b/cli/executor/ssh_test.go
@@ -1,0 +1,207 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func fakeExec(recorded *[]string, script string) func(context.Context, string, ...string) *exec.Cmd {
+	return func(_ context.Context, name string, args ...string) *exec.Cmd {
+		*recorded = append(*recorded, append([]string{name}, args...)...)
+		return exec.Command("sh", "-c", script)
+	}
+}
+
+func TestBuildRemoteScript(t *testing.T) {
+	tests := []struct {
+		name string
+		spec RunSpec
+		want string
+	}{
+		{
+			name: "simple command",
+			spec: RunSpec{Command: "echo", Args: []string{"hi"}},
+			want: "echo hi",
+		},
+		{
+			name: "no args",
+			spec: RunSpec{Command: "hostname"},
+			want: "hostname",
+		},
+		{
+			name: "env exported in sorted order",
+			spec: RunSpec{
+				Command: "echo",
+				Args:    []string{"hi"},
+				Env:     map[string]string{"B": "2", "A": "1"},
+			},
+			want: "export A='1'; export B='2'; echo hi",
+		},
+		{
+			name: "env value with single quote",
+			spec: RunSpec{
+				Command: "echo",
+				Env:     map[string]string{"A": "it's"},
+			},
+			want: "export A='it'\"'\"'s'; echo",
+		},
+		{
+			name: "working directory",
+			spec: RunSpec{Command: "pwd", Dir: "/tmp"},
+			want: "cd '/tmp'; pwd",
+		},
+		{
+			name: "as root",
+			spec: RunSpec{Command: "podman", Args: []string{"ps"}, AsRoot: true},
+			want: "sudo podman ps",
+		},
+		{
+			name: "env, dir, and as root combined",
+			spec: RunSpec{
+				Command: "ls",
+				Env:     map[string]string{"A": "1"},
+				Dir:     "/x",
+				AsRoot:  true,
+			},
+			want: "export A='1'; cd '/x'; sudo ls",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildRemoteScript(tt.spec)
+			if got != tt.want {
+				t.Errorf("BuildRemoteScript(%+v) = %q, want %q", tt.spec, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSSHExecutorRunInvocation(t *testing.T) {
+	var recorded []string
+	ex := &SSHExecutor{instance: "bloud-dev", newCmd: fakeExec(&recorded, "echo fake-out")}
+	res, err := ex.Run(context.Background(), RunSpec{Command: "echo", Args: []string{"hi"}})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := []string{"limactl", "shell", "--start", "bloud-dev", "bash", "-c", "echo hi"}
+	if !slices.Equal(recorded, want) {
+		t.Fatalf("invocation = %q, want %q", recorded, want)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0", res.ExitCode)
+	}
+	if res.Stdout != "fake-out\n" {
+		t.Fatalf("Stdout = %q, want %q", res.Stdout, "fake-out\n")
+	}
+}
+
+func TestSSHExecutorRunScriptReflectsSpec(t *testing.T) {
+	var recorded []string
+	ex := &SSHExecutor{instance: "bloud-dev", newCmd: fakeExec(&recorded, "echo ok")}
+	if _, err := ex.Run(context.Background(), RunSpec{
+		Command: "./host-agent",
+		Dir:     "/runtime",
+		Env:     map[string]string{"BLOUD_DATA_DIR": "/runtime/data"},
+	}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	want := []string{
+		"limactl", "shell", "--start", "bloud-dev", "bash", "-c",
+		"export BLOUD_DATA_DIR='/runtime/data'; cd '/runtime'; ./host-agent",
+	}
+	if !slices.Equal(recorded, want) {
+		t.Fatalf("invocation = %q, want %q", recorded, want)
+	}
+}
+
+func TestSSHExecutorRunFailure(t *testing.T) {
+	var recorded []string
+	ex := &SSHExecutor{instance: "bloud-dev", newCmd: fakeExec(&recorded, "echo fake-err >&2; exit 3")}
+	res, err := ex.Run(context.Background(), RunSpec{Command: "false"})
+	if err == nil {
+		t.Fatal("Run() error = nil, want non-nil")
+	}
+	if res.ExitCode != 3 {
+		t.Fatalf("ExitCode = %d, want 3", res.ExitCode)
+	}
+	if res.Stderr != "fake-err\n" {
+		t.Fatalf("Stderr = %q, want %q", res.Stderr, "fake-err\n")
+	}
+}
+
+func TestSSHExecutorCopyToFile(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "bin")
+	if err := os.WriteFile(src, []byte("x"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	var recorded []string
+	ex := &SSHExecutor{instance: "bloud-dev", newCmd: fakeExec(&recorded, "true")}
+	if err := ex.CopyTo(context.Background(), src, "/runtime/host-agent/host-agent"); err != nil {
+		t.Fatalf("CopyTo() error = %v", err)
+	}
+	want := []string{"limactl", "copy", src, "bloud-dev:/runtime/host-agent/host-agent"}
+	if !slices.Equal(recorded, want) {
+		t.Fatalf("invocation = %q, want %q", recorded, want)
+	}
+}
+
+func TestSSHExecutorCopyToDirIsRecursive(t *testing.T) {
+	dir := t.TempDir()
+	var recorded []string
+	ex := &SSHExecutor{instance: "bloud-dev", newCmd: fakeExec(&recorded, "true")}
+	if err := ex.CopyTo(context.Background(), dir, "/runtime/web/build"); err != nil {
+		t.Fatalf("CopyTo() error = %v", err)
+	}
+	want := []string{"limactl", "copy", "-r", dir, "bloud-dev:/runtime/web/build"}
+	if !slices.Equal(recorded, want) {
+		t.Fatalf("invocation = %q, want %q", recorded, want)
+	}
+}
+
+func TestSSHExecutorCopyFrom(t *testing.T) {
+	var recorded []string
+	ex := &SSHExecutor{instance: "bloud-dev", newCmd: fakeExec(&recorded, "true")}
+	if err := ex.CopyFrom(context.Background(), "/runtime/logs.txt", "/tmp/logs.txt"); err != nil {
+		t.Fatalf("CopyFrom() error = %v", err)
+	}
+	want := []string{"limactl", "copy", "bloud-dev:/runtime/logs.txt", "/tmp/logs.txt"}
+	if !slices.Equal(recorded, want) {
+		t.Fatalf("invocation = %q, want %q", recorded, want)
+	}
+}
+
+func TestSSHExecutorRunStream(t *testing.T) {
+	var recorded []string
+	ex := &SSHExecutor{instance: "bloud-dev", newCmd: fakeExec(&recorded, "echo streamed")}
+	var stdout, stderr strings.Builder
+	if err := ex.RunStream(context.Background(),
+		RunSpec{Command: "hostname"}, &stdout, &stderr); err != nil {
+		t.Fatalf("RunStream() error = %v", err)
+	}
+	want := []string{"limactl", "shell", "--start", "bloud-dev", "bash", "-c", "hostname"}
+	if !slices.Equal(recorded, want) {
+		t.Fatalf("invocation = %q, want %q", recorded, want)
+	}
+	if stdout.String() != "streamed\n" {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), "streamed\n")
+	}
+}
+
+func TestSSHExecutorInteractiveShell(t *testing.T) {
+	var recorded []string
+	ex := &SSHExecutor{instance: "bloud-dev", newCmd: fakeExec(&recorded, "exit")}
+	var stdout, stderr strings.Builder
+	if err := ex.InteractiveShell(context.Background(), &stdout, &stderr, strings.NewReader("")); err != nil {
+		t.Fatalf("InteractiveShell() error = %v", err)
+	}
+	want := []string{"limactl", "shell", "bloud-dev"}
+	if !slices.Equal(recorded, want) {
+		t.Fatalf("invocation = %q, want %q", recorded, want)
+	}
+}

--- a/cli/executor/sshhost_test.go
+++ b/cli/executor/sshhost_test.go
@@ -1,0 +1,103 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+type stubExecutor struct {
+	runResult ExecResult
+	runErr    error
+	runCalled bool
+	runSpec   RunSpec
+}
+
+func (s *stubExecutor) Run(_ context.Context, spec RunSpec) (ExecResult, error) {
+	s.runCalled = true
+	s.runSpec = spec
+	return s.runResult, s.runErr
+}
+
+func (s *stubExecutor) RunStream(_ context.Context, _ RunSpec, _, _ io.Writer) error { return nil }
+func (s *stubExecutor) CopyTo(_ context.Context, _, _ string) error                  { return nil }
+func (s *stubExecutor) CopyFrom(_ context.Context, _, _ string) error                { return nil }
+
+func TestIsVMNameRunning(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{name: "matching running instance", out: `{"name":"bloud-dev","status":"Running"}` + "\n", want: true},
+		{name: "matching stopped instance", out: `{"name":"bloud-dev","status":"Stopped"}` + "\n", want: false},
+		{name: "other instances running", out: `{"name":"other","status":"Running"}` + "\n", want: false},
+		{name: "empty output", out: "", want: false},
+		{name: "malformed line skipped", out: `not json` + "\n" + `{"name":"bloud-dev","status":"Running"}`, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVMNameRunning(tt.out, "bloud-dev"); got != tt.want {
+				t.Errorf("IsVMNameRunning(%q) = %v, want %v", tt.out, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsVMNamePresent(t *testing.T) {
+	out := `{"name":"other","status":"Running"}` + "\n" + `{"name":"bloud-dev","status":"Stopped"}`
+	if !IsVMNamePresent(out, "bloud-dev") {
+		t.Error("IsVMNamePresent() = false, want true")
+	}
+	if IsVMNamePresent(out, "missing") {
+		t.Error("IsVMNamePresent() = true, want false")
+	}
+}
+
+func TestSSHHostReadyRunning(t *testing.T) {
+	local := &stubExecutor{runResult: ExecResult{Stdout: `{"name":"bloud-dev","status":"Running"}` + "\n"}}
+	host := NewSSHHost("bloud-dev", &stubExecutor{}, local, nil, DataDirs{})
+	if !host.Ready() {
+		t.Error("Ready() = false, want true")
+	}
+	if !local.runCalled {
+		t.Fatal("local executor was not invoked")
+	}
+	if local.runSpec.Command != "limactl" || len(local.runSpec.Args) != 2 || local.runSpec.Args[0] != "list" || local.runSpec.Args[1] != "--json" {
+		t.Fatalf("ready check invoked %q %q, want limactl list --json", local.runSpec.Command, local.runSpec.Args)
+	}
+}
+
+func TestSSHHostReadyStopped(t *testing.T) {
+	local := &stubExecutor{runResult: ExecResult{Stdout: `{"name":"bloud-dev","status":"Stopped"}` + "\n"}}
+	host := NewSSHHost("bloud-dev", &stubExecutor{}, local, nil, DataDirs{})
+	if host.Ready() {
+		t.Error("Ready() = true, want false")
+	}
+}
+
+func TestSSHHostReadyError(t *testing.T) {
+	local := &stubExecutor{runErr: errors.New("limactl not found")}
+	host := NewSSHHost("bloud-dev", &stubExecutor{}, local, nil, DataDirs{})
+	if host.Ready() {
+		t.Error("Ready() = true, want false")
+	}
+}
+
+func TestSSHHostDescription(t *testing.T) {
+	remote := &stubExecutor{}
+	ports := map[string]string{"host-agent": "3000", "traefik": "8080"}
+	dirs := DataDirs{HostAgentDir: "/runtime/host-agent", DataDir: "/runtime/data", AppsDir: "/repo/apps"}
+	host := NewSSHHost("bloud-dev", remote, &stubExecutor{}, ports, dirs)
+
+	if host.Executor() != remote {
+		t.Error("Executor() did not return the remote executor")
+	}
+	if len(host.Ports()) != 2 || host.Ports()["traefik"] != "8080" {
+		t.Fatalf("Ports() = %v, want traefik:8080", host.Ports())
+	}
+	if host.DataDirs() != dirs {
+		t.Fatalf("DataDirs() = %v, want %v", host.DataDirs(), dirs)
+	}
+}

--- a/cli/vm/exec.go
+++ b/cli/vm/exec.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 )
 
@@ -14,24 +13,4 @@ func LocalExec(command string) (string, error) {
 		return string(output), fmt.Errorf("command failed: %w", err)
 	}
 	return string(output), nil
-}
-
-// LocalExecStream runs a command locally with stdout/stderr piped to the terminal
-func LocalExecStream(command string) error {
-	cmd := exec.Command("bash", "-c", command)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-// LocalInteractive runs a command locally with full stdin/stdout/stderr attached
-func LocalInteractive(command string) error {
-	if command == "" {
-		command = "bash"
-	}
-	cmd := exec.Command("bash", "-c", command)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
 }


### PR DESCRIPTION
## Summary

Introduces the three-layer CLI backend abstraction per the CLI backend design, so `./bloud` no longer hardcodes Lima:

- **`cli/executor/`** — `Executor` (`Run` / `RunStream` / `CopyTo` / `CopyFrom`), `Host`, `DataDirs`; implementations `LocalExecutor`, `SSHExecutor` (via `limactl shell`/`copy`), and `SSHHost` (a concrete `Host` for VM/remote targets).
- **`cli/backend/`** — `Backend` interface + `LimaBackend` (ensure VM exists/running via `limactl list`/`create`/`start`, `Destroy`, `Host()`).
- **`cli/dev.go`** — all dev lifecycle commands (`dev`, `stop`, `status`, `logs`, `attach`, `shell`, `services`, `reset`, `destroy`) now delegate through `backend.Host().Executor()` instead of calling `limactl` directly.

Built red/green TDD; `RunStream` added to the `Executor` interface (streaming needed for logs/attach/dev-run).

## Scope notes

- `validate.go` and `e2e_lifecycle.go` still invoke `limactl` directly — migrating those to the backend is the follow-up.
- Verified against a live `bloud-dev` VM: `status`, `shell`, `services`, `attach`, quoted multi-word `shell`.
- `go build` / `go vet` / `go test ./...` all green (cli + host-agent).

## Deferred

- Route `validate.go` integration tier and `e2e_lifecycle.go` through the backend.
- `LocalHost` / `NativeBackend` (design Phase 4).