### PR TITLE
feat: get e2e Playwright tests passing against QEMU backend

### DIFF
--- a/apps/authentik/scripts/set_admin_password.py
+++ b/apps/authentik/scripts/set_admin_password.py
@@ -1,13 +1,30 @@
 import os
-from authentik.core.models import User
+from authentik.core.models import User, Group
+
+username = 'admin'
+password = os.environ.get('BLOUD_ADMIN_PASSWORD', 'password')
+email = os.environ.get('BLOUD_ADMIN_EMAIL', 'admin@localhost')
+
+user, created = User.objects.get_or_create(
+    username=username,
+    defaults={
+        'name': 'Admin',
+        'email': email,
+        'is_active': True,
+        'path': 'users',
+    },
+)
+user.set_password(password)
+user.email = email
+user.save()
 
 try:
-    user = User.objects.get(username='akadmin')
-    user.set_password(os.environ['BLOUD_ADMIN_PASSWORD'])
-    user.email = os.environ['BLOUD_ADMIN_EMAIL']
-    user.save()
-    print('OK')
-except User.DoesNotExist:
-    print('OK')  # User will be created by bootstrap
-except Exception as e:
-    print(f'ERROR: {e}')
+    group = Group.objects.get(name='authentik Admins')
+    group.users.add(user)
+except Group.DoesNotExist:
+    pass
+
+if created:
+    print(f'OK: created admin user {username}')
+else:
+    print(f'OK: admin user {username} exists')

--- a/cli/backend/backend.go
+++ b/cli/backend/backend.go
@@ -16,4 +16,6 @@ type Backend interface {
 	Destroy(ctx context.Context) error
 	// Host returns the runtime host for executing commands.
 	Host() executor.Host
+	// SyncProject copies the host project into the guest.
+	SyncProject(ctx context.Context) error
 }

--- a/cli/backend/lima.go
+++ b/cli/backend/lima.go
@@ -63,6 +63,8 @@ func (b *LimaBackend) Destroy(ctx context.Context) error {
 	}
 	return nil
 }
+// SyncProject is a no-op for Lima — the project is mounted via 9p.
+func (b *LimaBackend) SyncProject(ctx context.Context) error { return nil }
 
 // Host returns the runtime host backed by the Lima VM.
 func (b *LimaBackend) Host() executor.Host {

--- a/cli/backend/qemu.go
+++ b/cli/backend/qemu.go
@@ -77,15 +77,15 @@ func (b *QEMUBackend) Create(ctx context.Context) error {
 	// Debian cloud images ship no 9p/virtiofs kernel modules, so a live host
 	// mount is unavailable; instead rsync the project into the guest so the
 	// dev loop (compose.yml, apps/, services/) sees a working copy.
-	if err := b.syncProject(ctx); err != nil {
+	if err := b.SyncProject(ctx); err != nil {
 		return fmt.Errorf("sync project into guest: %w", err)
 	}
 	return nil
 }
 
-// syncProject copies the host project dir into the guest (incremental via
+// SyncProject copies the host project dir into the guest (incremental via
 // rsync), skipping heavy/irrelevant dirs. The guest path equals the host path.
-func (b *QEMUBackend) syncProject(ctx context.Context) error {
+func (b *QEMUBackend) SyncProject(ctx context.Context) error {
 	args := []string{
 		"-a", "-e", "ssh -p " + strconv.Itoa(qemuSSHPort) + " -i " + filepath.Join(b.dir, "id_ed25519"),
 		"--exclude=.git", "--exclude=.forgejo", "--exclude=.bloud",

--- a/cli/dev.go
+++ b/cli/dev.go
@@ -86,6 +86,18 @@ func vmInstance() string {
 	return limaInstance()
 }
 
+// trustedLocalNetsEnv returns the BLOUD_TRUSTED_LOCAL_NETS value for the
+// host-agent. QEMU slirp NAT presents host-forwarded connections from the
+// gateway (10.0.2.2), not loopback, so the host-agent must trust that subnet
+// for host-side API calls (e.g. ./bloud install, e2e). Lima forwards to
+// loopback, so no trusted nets are needed.
+func trustedLocalNetsEnv() string {
+	if backendName() == "qemu" {
+		return "10.0.2.0/24"
+	}
+	return ""
+}
+
 // vmLabel is the human-readable VM name for the selected backend.
 func vmLabel() string {
 	if backendName() == "qemu" {
@@ -537,6 +549,7 @@ func cmdDev() int {
 			"BLOUD_DATA_DIR":           dirs.DataDir,
 			"BLOUD_APPS_DIR":           dirs.AppsDir,
 			"BLOUD_TRAEFIK_DYNAMIC_DIR": dirs.DataDir + "/traefik/dynamic",
+			"BLOUD_TRUSTED_LOCAL_NETS":  trustedLocalNetsEnv(),
 		},
 	}, os.Stdout, os.Stderr)
 	if runErr != nil && !isSignalExit(runErr) {

--- a/cli/e2e_lifecycle.go
+++ b/cli/e2e_lifecycle.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -12,6 +13,8 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+
+	"codeberg.org/d-buckner/bloud/cli/backend"
 )
 
 const (
@@ -21,7 +24,9 @@ const (
 type lifecycleConfig struct {
 	root       string
 	lima       string
+	qemu       string       // QEMU instance name (auto-provisioned)
 	sshTarget  string
+	sshKeyFile string       // SSH key file for QEMU (auto-derived)
 	envFile    string
 	baseURL    string
 	remoteDir  string
@@ -62,6 +67,7 @@ func parseLifecycleConfig(root string, args []string, getenv func(string) string
 	cfg := lifecycleConfig{
 		root:       root,
 		lima:       getenv("BLOUD_E2E_LIMA_INSTANCE"),
+		qemu:       getenv("BLOUD_E2E_QEMU_INSTANCE"),
 		sshTarget:  getenv("BLOUD_E2E_SSH_TARGET"),
 		envFile:    getenv("BLOUD_E2E_ENV_FILE"),
 		baseURL:    getenv("BLOUD_URL"),
@@ -75,8 +81,13 @@ func parseLifecycleConfig(root string, args []string, getenv func(string) string
 	if cfg.remoteDir == "" {
 		cfg.remoteDir = "/var/tmp/bloud-e2e-runtime"
 	}
-	if cfg.lima == "" && cfg.sshTarget == "" {
+	if cfg.lima == "" && cfg.qemu == "" && cfg.sshTarget == "" {
 		cfg.lima = "bloud-dev"
+	}
+	if cfg.qemu != "" && cfg.sshTarget == "" {
+		// Derive SSH target and key from QEMU instance
+		cfg.sshTarget = "bloud@127.0.0.1"
+		cfg.sshKeyFile = filepath.Join(root, ".bloud", "qemu", cfg.qemu, "id_ed25519")
 	}
 	if cfg.envFile == "" && cfg.lima != "" {
 		cfg.envFile = filepath.Join(root, "dev", "host-agent.env")
@@ -96,6 +107,9 @@ func parseLifecycleConfig(root string, args []string, getenv func(string) string
 	if cfg.traefikDir == "" {
 		cfg.traefikDir = filepath.Join(cfg.remoteDir, "data", "traefik", "dynamic")
 	}
+	if cfg.redisAddr == "" && cfg.qemu != "" {
+		cfg.redisAddr = "127.0.0.1:6379"
+	}
 
 	flags := flag.NewFlagSet("e2e lifecycle", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
@@ -110,8 +124,12 @@ func parseLifecycleConfig(root string, args []string, getenv func(string) string
 	if flags.NArg() != 0 {
 		return cfg, false, fmt.Errorf("unexpected lifecycle arguments: %s", strings.Join(flags.Args(), " "))
 	}
-	if cfg.lima != "" && cfg.sshTarget != "" {
-		return cfg, false, fmt.Errorf("set only one of BLOUD_E2E_LIMA_INSTANCE or BLOUD_E2E_SSH_TARGET")
+	if cfg.lima != "" && (cfg.qemu != "" || cfg.sshTarget != "") {
+		return cfg, false, fmt.Errorf("set only one of BLOUD_E2E_LIMA_INSTANCE, BLOUD_E2E_QEMU_INSTANCE, or BLOUD_E2E_SSH_TARGET")
+	}
+	if cfg.qemu != "" && cfg.sshTarget != "" && cfg.sshKeyFile == "" {
+		// sshTarget was set manually, not derived from QEMU
+		return cfg, false, fmt.Errorf("BLOUD_E2E_QEMU_INSTANCE and BLOUD_E2E_SSH_TARGET cannot be used together")
 	}
 	if cfg.envFile == "" {
 		return cfg, false, fmt.Errorf("BLOUD_E2E_ENV_FILE is required")
@@ -198,6 +216,9 @@ func (r *lifecycle) run() (runErr error) {
 		return fmt.Errorf("host preflight: %w", err)
 	}
 	if err := r.prepareLimaTarget(); err != nil {
+		return err
+	}
+	if err := r.prepareQEMUTarget(); err != nil {
 		return err
 	}
 
@@ -310,6 +331,9 @@ func renderLifecycleHostAgentUnit(cfg lifecycleConfig) string {
 	if cfg.redisAddr != "" {
 		fmt.Fprintf(&extraEnv, "Environment=BLOUD_REDIS_ADDR=%s\n", cfg.redisAddr)
 	}
+	if cfg.qemu != "" {
+		fmt.Fprintf(&extraEnv, "Environment=BLOUD_TRUSTED_LOCAL_NETS=10.0.2.0/24\n")
+	}
 	return fmt.Sprintf(`[Unit]
 Description=Bloud E2E host agent
 After=network-online.target podman.socket
@@ -415,21 +439,33 @@ func (r *lifecycle) remoteOutput(script string, args ...string) (string, error) 
 
 func (r *lifecycle) remoteCommand(_ string, args ...string) *exec.Cmd {
 	commandArgs := []string{}
-	name := "ssh"
 	if r.cfg.lima != "" {
-		name = "limactl"
+		name := "limactl"
 		commandArgs = append(commandArgs, "shell", "--start", r.cfg.lima, "bash", "-se", "--")
-	} else {
-		commandArgs = append(commandArgs, r.cfg.sshTarget, "bash", "-se", "--")
-	}
-	for _, arg := range args {
-		if r.cfg.lima != "" {
+		for _, arg := range args {
 			commandArgs = append(commandArgs, arg)
-		} else {
+		}
+		return exec.Command(name, commandArgs...)
+	} else if r.cfg.qemu != "" {
+		name := "ssh"
+		commandArgs = append(commandArgs,
+			"-i", r.cfg.sshKeyFile,
+			"-p", "2222",
+			"-o", "StrictHostKeyChecking=accept-new",
+			"-o", "ConnectTimeout=5",
+			r.cfg.sshTarget, "bash", "-se", "--")
+		for _, arg := range args {
 			commandArgs = append(commandArgs, shellQuote(arg))
 		}
+		return exec.Command(name, commandArgs...)
+	} else {
+		name := "ssh"
+		commandArgs = append(commandArgs, r.cfg.sshTarget, "bash", "-se", "--")
+		for _, arg := range args {
+			commandArgs = append(commandArgs, shellQuote(arg))
+		}
+		return exec.Command(name, commandArgs...)
 	}
-	return exec.Command(name, commandArgs...)
 }
 
 func (r *lifecycle) copyDirectory(source, destination string) error {
@@ -437,16 +473,25 @@ func (r *lifecycle) copyDirectory(source, destination string) error {
 		return r.remoteRun(`rm -rf "$2"
 mkdir -p "$2"
 cp -a "$1/." "$2/"`, source, destination)
+	} else if r.cfg.qemu != "" {
+		sshCmd := fmt.Sprintf("ssh -i %s -p 2222 -o StrictHostKeyChecking=accept-new", shellQuote(r.cfg.sshKeyFile))
+		args := []string{"-a", "--delete", "-e", sshCmd, source + string(os.PathSeparator), r.cfg.sshTarget + ":" + shellQuote(destination) + "/"}
+		return r.localRun(r.cfg.root, os.Environ(), "rsync", args...)
+	} else {
+		args := []string{"-a", "--delete", source + string(os.PathSeparator), r.cfg.sshTarget + ":" + shellQuote(destination) + "/"}
+		return r.localRun(r.cfg.root, os.Environ(), "rsync", args...)
 	}
-	args := []string{"-a", "--delete", source + string(os.PathSeparator), r.cfg.sshTarget + ":" + shellQuote(destination) + "/"}
-	return r.localRun(r.cfg.root, os.Environ(), "rsync", args...)
 }
 
 func (r *lifecycle) copyFile(source, destination string) error {
 	if r.cfg.lima != "" {
 		return r.localRun(r.cfg.root, os.Environ(), "limactl", "copy", source, r.cfg.lima+":"+destination)
+	} else if r.cfg.qemu != "" {
+		sshCmd := fmt.Sprintf("ssh -i %s -p 2222 -o StrictHostKeyChecking=accept-new", shellQuote(r.cfg.sshKeyFile))
+		return r.localRun(r.cfg.root, os.Environ(), "rsync", "-a", "-e", sshCmd, source, r.cfg.sshTarget+":"+shellQuote(destination))
+	} else {
+		return r.localRun(r.cfg.root, os.Environ(), "rsync", "-a", source, r.cfg.sshTarget+":"+shellQuote(destination))
 	}
-	return r.localRun(r.cfg.root, os.Environ(), "rsync", "-a", source, r.cfg.sshTarget+":"+shellQuote(destination))
 }
 
 func (r *lifecycle) remotePath(relative string) string {
@@ -498,6 +543,30 @@ systemctl --user daemon-reload >/dev/null 2>&1 || true`
 	if err := r.remoteRun(script, lifecycleHostAgentUnit, r.cfg.remoteHome, r.cfg.remoteDir); err != nil {
 		errorf("failed to clean up remote deployment: %v", err)
 	}
+}
+
+func (r *lifecycle) prepareQEMUTarget() error {
+	if r.cfg.qemu == "" {
+		return nil
+	}
+	r.step("Provisioning QEMU VM")
+	bk := backend.NewQEMUBackend(r.cfg.qemu, r.cfg.root)
+	if err := bk.Create(context.Background()); err != nil {
+		return fmt.Errorf("QEMU VM provisioning failed: %w", err)
+	}
+	if err := bk.SyncProject(context.Background()); err != nil {
+		return fmt.Errorf("QEMU project sync failed: %w", err)
+	}
+	if r.cfg.redisAddr == "" {
+		if err := r.remoteRun(`if ! timeout 2 bash -c '</dev/tcp/127.0.0.1/6379' 2>/dev/null; then
+  podman rm -f bloud-e2e-redis >/dev/null 2>&1 || true
+  podman run -d --name bloud-e2e-redis -p 127.0.0.1:6379:6379 docker.io/redis:7-alpine >/dev/null
+fi`); err != nil {
+			return fmt.Errorf("prepare QEMU Redis port: %w", err)
+		}
+		r.cfg.redisAddr = "127.0.0.1:6379"
+	}
+	return nil
 }
 
 func (r *lifecycle) prepareLimaTarget() error {

--- a/e2e/lib/api.ts
+++ b/e2e/lib/api.ts
@@ -2,7 +2,7 @@
 const BASE_URL = process.env.BLOUD_API_URL ?? 'http://localhost:3000';
 
 interface InstalledApp {
-  name: string;
+  catalog_id: string;
   status: string;
   display_name: string;
   is_system: boolean;
@@ -20,8 +20,8 @@ async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export async function getAppStatus(name: string): Promise<string | null> {
-  const apps = await fetchJSON<InstalledApp[]>('/api/apps/installed');
-  const app = apps.find((a) => a.name === name);
+  const body = await fetchJSON<{ apps: InstalledApp[] }>('/api/apps/installed');
+  const app = body.apps.find((a) => a.catalog_id === name);
   return app?.status ?? null;
 }
 

--- a/services/host-agent/cmd/host-agent/main.go
+++ b/services/host-agent/cmd/host-agent/main.go
@@ -114,6 +114,7 @@ func runServer() {
 		TSAuthKey:         cfg.TSAuthKey,
 		HostLabel:         cfg.HostLabel,
 		RedisAddr:         cfg.RedisAddr,
+		TrustedLocalNets:  cfg.TrustedLocalNets,
 		LDAPOutput:        cfg.LDAPOutput(),
 		Registry:          registry,
 		TemplateVars:      templateVars,

--- a/services/host-agent/internal/api/auth.go
+++ b/services/host-agent/internal/api/auth.go
@@ -80,14 +80,33 @@ func (r *authConfigRef) Ensure() {
 }
 
 // isLocalRequest returns true if the request originates from localhost.
-// Requests from localhost have implicit CLI-level trust.
-func isLocalRequest(r *http.Request) bool {
+// Requests from localhost have implicit CLI-level trust. trustedNets lists
+// additional CIDRs/IPs treated as local (e.g. a dev VM's slirp NAT gateway,
+// where host-forwarded connections arrive from a non-loopback source).
+func isLocalRequest(r *http.Request, trustedNets []string) bool {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		host = r.RemoteAddr
 	}
 	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() {
+		return true
+	}
+	for _, netStr := range trustedNets {
+		if _, cidr, err := net.ParseCIDR(netStr); err == nil {
+			if cidr.Contains(ip) {
+				return true
+			}
+			continue
+		}
+		if net.ParseIP(netStr).Equal(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // getUserFromContext retrieves the user from the request context.

--- a/services/host-agent/internal/api/auth_test.go
+++ b/services/host-agent/internal/api/auth_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsLocalRequest_TrustedNets(t *testing.T) {
+	cases := []struct {
+		name       string
+		remoteAddr string
+		trusted    []string
+		want       bool
+	}{
+		{"loopback", "127.0.0.1:1234", nil, true},
+		{"loopback ipv6", "[::1]:1234", nil, true},
+		{"nonlocal no trusted", "10.0.2.2:1234", nil, false},
+		{"nonlocal trusted cidr", "10.0.2.2:1234", []string{"10.0.2.0/24"}, true},
+		{"nonlocal outside cidr", "10.0.2.2:1234", []string{"10.0.3.0/24"}, false},
+		{"nonlocal trusted bare ip", "10.0.2.2:1234", []string{"10.0.2.2"}, true},
+		{"nonlocal multiple nets", "10.0.2.9:1234", []string{"192.168.0.0/16", "10.0.2.0/24"}, true},
+		{"nonlocal invalid net ignored", "10.0.2.2:1234", []string{"not-a-cidr"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = tc.remoteAddr
+			if got := isLocalRequest(r, tc.trusted); got != tc.want {
+				t.Fatalf("isLocalRequest(%q, %v) = %v, want %v", tc.remoteAddr, tc.trusted, got, tc.want)
+			}
+		})
+	}
+}

--- a/services/host-agent/internal/api/router.go
+++ b/services/host-agent/internal/api/router.go
@@ -214,7 +214,7 @@ func NewRouter(
 
 		// Authenticated routes
 		api.Group(func(auth chi.Router) {
-			auth.Use(authMiddlewareFn(sessionStore, logger))
+			auth.Use(authMiddlewareFn(sessionStore, logger, cfg.TrustedLocalNets))
 
 			// User-accessible routes (registered directly)
 			NewAppsRouter(appsMod, auth)
@@ -459,10 +459,10 @@ func rebuildStreamHandler() http.HandlerFunc {
 
 // ---- Middleware ----
 
-func authMiddlewareFn(sessionStore *store.SessionStore, logger *slog.Logger) func(http.Handler) http.Handler {
+func authMiddlewareFn(sessionStore *store.SessionStore, logger *slog.Logger, trustedNets []string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if isLocalRequest(r) {
+			if isLocalRequest(r, trustedNets) {
 				user := &store.User{Username: "_cli", Role: store.RoleAdmin}
 				ctx := context.WithValue(r.Context(), userContextKey, user)
 				next.ServeHTTP(w, r.WithContext(ctx))

--- a/services/host-agent/internal/api/server.go
+++ b/services/host-agent/internal/api/server.go
@@ -66,6 +66,9 @@ type ServerConfig struct {
 	TSAuthKey         string
 	HostLabel         string
 	RedisAddr         string
+	// TrustedLocalNets lists CIDRs/IPs treated as local (loopback-equivalent)
+	// for host-agent API requests (e.g. QEMU slirp NAT gateway).
+	TrustedLocalNets []string
 	RefreshAuthentikToken func() string
 	LDAPOutput       *configurator.LDAPOutput
 	Registry         configurator.RegistryInterface

--- a/services/host-agent/internal/config/config.go
+++ b/services/host-agent/internal/config/config.go
@@ -2,9 +2,11 @@ package config
 
 import (
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"codeberg.org/d-buckner/bloud/services/host-agent/internal/secrets"
 )
@@ -16,6 +18,10 @@ type Config struct {
 	AppsDir           string // Path to apps/ directory containing app definitions
 	TraefikDynamicDir string // Path to Traefik dynamic config directory (contains apps-routes.yml)
 	RedisAddr         string // Redis address for session storage
+	// TrustedLocalNets lists CIDRs/IPs treated as local (loopback-equivalent)
+	// for host-agent API requests. Used by dev VMs (e.g. QEMU slirp NAT where
+	// host-forwarded connections arrive from the gateway, not loopback).
+	TrustedLocalNets []string
 	// SSO configuration
 	SSOHostSecret   string // Master secret for deriving client secrets
 	SSOBaseURL      string // Base URL for callbacks (e.g., "http://localhost:8080")
@@ -87,7 +93,8 @@ func LoadWithLogger(logger *slog.Logger) *Config {
 		DataDir:                dataDir,
 		AppsDir:                appsDir,
 		TraefikDynamicDir:      getEnv("BLOUD_TRAEFIK_DYNAMIC_DIR", filepath.Join(dataDir, "traefik", "dynamic")),
-		RedisAddr:              getEnv("BLOUD_REDIS_ADDR", "localhost:6379"),
+		RedisAddr:              getEnv("BLOUD_REDIS_ADDR", "127.0.0.1:6379"),
+		TrustedLocalNets:       splitNets(getEnv("BLOUD_TRUSTED_LOCAL_NETS", "")),
 		SSOHostSecret:          ssoHostSecret,
 		SSOBaseURL:             getEnv("BLOUD_SSO_BASE_URL", "http://localhost:8080"),
 		SSOAuthentikURL:        getEnv("BLOUD_SSO_AUTHENTIK_URL", "http://localhost:8080"),
@@ -118,6 +125,26 @@ func getDefaultDataDir() string {
 }
 
 // getEnv reads an environment variable or returns a default value
+// splitNets parses a comma-separated list of IPs/CIDRs into a slice.
+// Invalid entries are dropped; an empty value yields no trusted nets.
+func splitNets(raw string) []string {
+	var nets []string
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		_, _, err := net.ParseCIDR(part)
+		if err != nil {
+			if ip := net.ParseIP(part); ip == nil {
+				continue // neither CIDR nor bare IP — drop
+			}
+		}
+		nets = append(nets, part)
+	}
+	return nets
+}
+
 func getEnv(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value

--- a/services/host-agent/internal/config/config_test.go
+++ b/services/host-agent/internal/config/config_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitNets(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want []string
+	}{
+		{"", nil},
+		{"10.0.2.0/24", []string{"10.0.2.0/24"}},
+		{"10.0.2.2", []string{"10.0.2.2"}},
+		{"10.0.2.0/24, 10.0.3.2", []string{"10.0.2.0/24", "10.0.3.2"}},
+		{"bad, 10.0.2.2, not-a-cidr", []string{"10.0.2.2"}},
+		{" , 10.0.2.0/24 , ", []string{"10.0.2.0/24"}},
+	}
+	for _, tc := range cases {
+		got := splitNets(tc.raw)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("splitNets(%q) = %v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
- Fix Redis default from localhost:6379 to 127.0.0.1:6379 (IPv6 resolution on Linux caused no session store, disabling authentication)
- Add QEMU mode to e2e lifecycle: SSH/rsync transport, auto-provisioning, trusted nets (10.0.2.0/24 for slirp NAT), BLOUD_E2E_QEMU_INSTANCE env var
- Fix set_admin_password.py to create admin user with get_or_create and Group membership (was looking for akadmin; bootstrap skipped on existing DB)
- Export SyncProject and add to Backend interface; add no-op SyncProject to Lima
- Add QEMU auto-provisioning via QEMUBackend.Create() in e2e lifecycle