### PR TITLE
chore: add SPDX license headers to all source files

### DIFF
--- a/.forgejo/workflows/test.yml
+++ b/.forgejo/workflows/test.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 name: Test
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 name: CI
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 name: Test
 
 on:

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 
 # Skip if we're already amending (prevents infinite loop)
 if [ -n "$BLOUD_SKIP_TIME_REWRITE" ]; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 npm run test:precommit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ pruned to the newest 20).
 
 | Tier | Command | What happens |
 |---|---|---|
-| `fast` (~30s) | `./bloud validate --tier fast` | host-agent go tests, orchestrator race tests, apps go tests, cli go tests, web vitest + svelte-check |
+| `fast` (~30s) | `./bloud validate --tier fast` | host-agent go tests, orchestrator race tests, apps go tests, cli go tests, web vitest + svelte-check, license header check |
 | `changed` (default) | `./bloud validate` | `git diff` (default base `HEAD`; `--since <ref>`) → infer commands via `inference.paths` globs in validation.yaml; reports risk areas + affected apps; unmapped files drop confidence to "medium" |
 | `integration` | `./bloud validate --tier integration` | Requires the VM: builds host-agent, frontend, and the integration test binary locally; deploys them to the guest's `/var/tmp/bloud-validate-runtime` behind a systemd user service (`bloud-validate-host-agent.service`) plus `init-secrets`; waits for API convergence; then runs the prebuilt test binary in the VM (the tests install Jellyfin through the real API) |
 
@@ -122,8 +122,15 @@ npm run check --workspace=@bloud/host-agent-web   # svelte-check (typecheck)
 cd e2e && npx playwright test                     # browser e2e (see below)
 ```
 
-**Pre-commit hook (husky) runs `npm run test:precommit`** = host-agent + apps Go
-tests + web TS tests. Don't commit without it passing; don't disable the hook.
+**Pre-commit hook (husky) runs `npm run test:precommit`** = license header check
++ host-agent + apps Go tests + web TS tests. Don't commit without it passing;
+don't disable the hook.
+
+License headers: every source file starts with `// SPDX-License-Identifier: AGPL-3.0-only`
++ copyright line (syntax per language; `.svelte` files carry it inside `<script>`).
+`npm run license:check` verifies, `npm run license:fix` stamps. Excluded: JSON,
+go.mod/go.sum, docs, binaries, `*.golden.yml` testdata, and the runtime-managed
+`apps-routes.yml` (see `scripts/license-header.mjs`).
 
 ### Playwright e2e (`e2e/`)
 

--- a/apps/authentik/auth.yaml
+++ b/apps/authentik/auth.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 # Bloud override for Authentik's default authentication flow blueprint.
 # Replaces /blueprints/default/flow-default-authentication-flow.yaml inside the container
 # so username-only identification is set at the source rather than fighting ordering.

--- a/apps/authentik/branding/bloud-brand.yaml
+++ b/apps/authentik/branding/bloud-brand.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 # Authentik Blueprint for Bloud Branding
 # Applies custom branding to match the Bloud design system
 # CSS source: services/host-agent/web/static/authentik-branding.css

--- a/apps/authentik/configurator.go
+++ b/apps/authentik/configurator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package authentik
 
 import (

--- a/apps/authentik/metadata.yaml
+++ b/apps/authentik/metadata.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 name: authentik
 displayName: Authentik
 description: Open-source identity provider for SSO, user management, and authentication

--- a/apps/authentik/scripts/ensure_api_token.py
+++ b/apps/authentik/scripts/ensure_api_token.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 import os, time
 from authentik.core.models import Token, User, Group
 

--- a/apps/authentik/scripts/set_admin_password.py
+++ b/apps/authentik/scripts/set_admin_password.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 import os
 from authentik.core.models import User, Group
 

--- a/apps/authentik/server_configurator.go
+++ b/apps/authentik/server_configurator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package authentik
 
 import (

--- a/apps/immich/configurator.go
+++ b/apps/immich/configurator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package immich
 
 import (

--- a/apps/immich/metadata.yaml
+++ b/apps/immich/metadata.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 name: immich
 displayName: Immich
 description: Self-hosted photo and video management

--- a/apps/jellyfin/configurator.go
+++ b/apps/jellyfin/configurator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package jellyfin
 
 import (

--- a/apps/jellyfin/configurator_test.go
+++ b/apps/jellyfin/configurator_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package jellyfin
 
 import (

--- a/apps/jellyfin/metadata.yaml
+++ b/apps/jellyfin/metadata.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 name: jellyfin
 displayName: Jellyfin
 description: Free software media system for streaming movies, TV, and music

--- a/apps/navidrome/configurator.go
+++ b/apps/navidrome/configurator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package navidrome
 
 import (

--- a/apps/navidrome/metadata.yaml
+++ b/apps/navidrome/metadata.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 name: navidrome
 displayName: Navidrome
 description: Modern music server and streamer compatible with Subsonic/Airsonic clients

--- a/apps/traefik/metadata.yaml
+++ b/apps/traefik/metadata.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 name: traefik
 displayName: Traefik
 description: Cloud-native reverse proxy and load balancer with automatic HTTPS

--- a/cli/backend/backend.go
+++ b/cli/backend/backend.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package backend abstracts provisioning and lifecycle management of runtime
 // environments (Lima VM, native box, etc.).
 package backend

--- a/cli/backend/lima.go
+++ b/cli/backend/lima.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package backend
 
 import (

--- a/cli/backend/lima_test.go
+++ b/cli/backend/lima_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package backend
 
 import (

--- a/cli/backend/qemu.go
+++ b/cli/backend/qemu.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package backend
 
 import (

--- a/cli/backend/qemu_test.go
+++ b/cli/backend/qemu_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package backend
 
 import (

--- a/cli/depgraph.go
+++ b/cli/depgraph.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/cli/dev.go
+++ b/cli/dev.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/cli/e2e.go
+++ b/cli/e2e.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/cli/e2e_lifecycle.go
+++ b/cli/e2e_lifecycle.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/cli/e2e_lifecycle_test.go
+++ b/cli/e2e_lifecycle_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/cli/executor/executor.go
+++ b/cli/executor/executor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package executor abstracts command execution and file transfer to a
 // runtime host (local machine, SSH/Lima VM, etc.).
 package executor

--- a/cli/executor/executor_test.go
+++ b/cli/executor/executor_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package executor
 
 import (

--- a/cli/executor/host.go
+++ b/cli/executor/host.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package executor
 
 import (

--- a/cli/executor/local.go
+++ b/cli/executor/local.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package executor
 
 import (

--- a/cli/executor/ssh.go
+++ b/cli/executor/ssh.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package executor
 
 import (

--- a/cli/executor/ssh_test.go
+++ b/cli/executor/ssh_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package executor
 
 import (

--- a/cli/executor/sshhost_test.go
+++ b/cli/executor/sshhost_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package executor
 
 import (

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/cli/validate_test.go
+++ b/cli/validate_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/cli/vm/detect.go
+++ b/cli/vm/detect.go
@@ -1,1 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package vm

--- a/cli/vm/exec.go
+++ b/cli/vm/exec.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package vm
 
 import (

--- a/cli/vm/preflight.go
+++ b/cli/vm/preflight.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package vm
 
 import (

--- a/dev/lima.yaml
+++ b/dev/lima.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 # Lima VM for Bloud local development.
 # Creates a Debian 13 (Trixie) VM with podman for running the service stack.
 #

--- a/dev/qemu.yaml
+++ b/dev/qemu.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 # QEMU VM for Bloud local development (x86_64 via KVM on Linux).
 #
 # This file documents the QEMU backend's spec; the backend hardcodes it (same

--- a/e2e/lib/api.ts
+++ b/e2e/lib/api.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 // API calls go directly to the host-agent (loopback bypass, no auth needed).
 const BASE_URL = process.env.BLOUD_API_URL ?? 'http://localhost:3000';
 

--- a/e2e/lib/auth.ts
+++ b/e2e/lib/auth.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import type { Page } from '@playwright/test';
 import { LoginPage } from './loginPage';
 

--- a/e2e/lib/fixtures.ts
+++ b/e2e/lib/fixtures.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { test as base, expect, type Page } from '@playwright/test';
 import { ensureSignedIn } from './auth';
 import * as api from './api';

--- a/e2e/lib/loginPage.ts
+++ b/e2e/lib/loginPage.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import type { Page } from '@playwright/test';
 import { TEST_CREDS } from '../tests/constants';
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { defineConfig, devices } from '@playwright/test';
 
 const baseURL = process.env.BLOUD_URL ?? 'http://localhost:8080';

--- a/e2e/tests/constants.ts
+++ b/e2e/tests/constants.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 export const TEST_CREDS = {
   USERNAME: process.env.BLOUD_E2E_USERNAME ?? 'admin',
   PASSWORD: process.env.BLOUD_E2E_PASSWORD ?? 'password',

--- a/e2e/tests/immich.spec.ts
+++ b/e2e/tests/immich.spec.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { test, expect } from '../lib/fixtures';
 import { LoginPage } from '../lib/loginPage';
 

--- a/e2e/tests/jellyfin.spec.ts
+++ b/e2e/tests/jellyfin.spec.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { test, expect } from '../lib/fixtures';
 import { TEST_CREDS } from './constants';
 

--- a/e2e/tests/navidrome.spec.ts
+++ b/e2e/tests/navidrome.spec.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { test, expect } from '../lib/fixtures';
 import { LoginPage } from '../lib/loginPage';
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "test:go:all": "npm run test:go && npm run test:go:apps",
     "test:ts": "npm run test --workspace=@bloud/host-agent-web",
     "test:go:coverage": "cd services/host-agent && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out | tail -1",
+    "license:check": "node scripts/license-header.mjs check",
+    "license:fix": "node scripts/license-header.mjs fix",
     "test:unit": "npm run test:go:all && npm run test:ts",
-    "test:precommit": "npm run test:go:all && npm run test:ts",
+    "test:precommit": "npm run license:check && npm run test:go:all && npm run test:ts",
     "test:e2e": "npm --prefix e2e test",
     "show-report": "cd e2e && npx playwright show-report"
   },

--- a/scripts/license-header.mjs
+++ b/scripts/license-header.mjs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+//
+// license-header: check or fix SPDX license headers on tracked source files.
+//
+//   node scripts/license-header.mjs check   # exit 1 if any file lacks the header
+//   node scripts/license-header.mjs fix     # insert missing headers in place
+//
+// Header rules are per-language (see styleFor/fixFile). Generated files
+// (golden testdata, the runtime-managed Traefik routes file) and
+// no-comment formats (JSON, go.mod/go.sum) are excluded.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const HOLDER = 'Daniel Buckner';
+const YEAR = '2026';
+const SPDX = 'SPDX-License-Identifier: AGPL-3.0-only';
+const COPYRIGHT = `Copyright (c) ${YEAR} ${HOLDER}`;
+
+// Basenames that never carry a header (the two committed binaries should
+// really be untracked; excluded here so this tool stays quiet).
+const EXCLUDE_BASENAMES = new Set(['LICENSE', 'cli', 'host-agent']);
+
+// Extensions that never carry a header (no-comment formats, binaries, docs).
+const EXCLUDE_EXTS = new Set([
+  '.md', '.json', '.sum', '.mod', '.lock', '.txt', '.bin',
+  '.svg', '.png', '.jpg', '.gif', '.ico', '.woff', '.woff2',
+  '.gitignore',
+]);
+
+// Generated / fixture files: their content is owned by the code that
+// emits them, so a header would drift (or have to be mirrored in goldens).
+const EXCLUDE_PATHS = new Set([
+  'services/host-agent/internal/api/traefik/dynamic/apps-routes.yml',
+]);
+
+function isGenerated(file) {
+  return file.endsWith('.golden.yml') || file.includes('/testdata/');
+}
+
+function headerLines(style) {
+  switch (style) {
+    case 'slash': return [`// ${SPDX}`, `// ${COPYRIGHT}`];
+    case 'hash': return [`# ${SPDX}`, `# ${COPYRIGHT}`];
+    case 'dash': return [`-- ${SPDX}`, `-- ${COPYRIGHT}`];
+    case 'cblock': return [`/* ${SPDX}`, ` * ${COPYRIGHT}`, ` */`];
+    case 'html': return [`<!-- ${SPDX}`, `     ${COPYRIGHT} -->`];
+    default: throw new Error(`unknown header style: ${style}`);
+  }
+}
+
+function styleFor(file) {
+  if (file.endsWith('.go') || file.endsWith('.ts') || file.endsWith('.js') ||
+      file.endsWith('.svelte')) return 'slash';
+  if (file.endsWith('.py') || file.endsWith('.yaml') || file.endsWith('.yml') ||
+      file.endsWith('.toml') || file.endsWith('.sh') || file.startsWith('.husky/')) return 'hash';
+  if (file.endsWith('.sql')) return 'dash';
+  if (file.endsWith('.css')) return 'cblock';
+  if (file.endsWith('.html')) return 'html';
+  return null;
+}
+
+function extOf(file) {
+  const base = file.split('/').pop();
+  const i = base.lastIndexOf('.');
+  return i > 0 ? base.slice(i) : '';
+}
+
+function isHeadered(lines) {
+  const head = lines.slice(0, 12).join('\n');
+  return head.includes(SPDX) && head.includes(COPYRIGHT);
+}
+
+// Returns the corrected content, or null when the file should be skipped.
+function fixContent(file, content) {
+  const style = styleFor(file);
+  if (!style) return null;
+  const lines = content.split('\n');
+  const header = headerLines(style);
+
+  if (file.endsWith('.svelte')) {
+    // Inside the <script> block so it is unambiguously a code comment and
+    // never part of the component markup.
+    const idx = lines.findIndex((l) => /^\s*<script[^>]*>/.test(l));
+    if (idx === -1) return null;
+    lines.splice(idx + 1, 0, ...header);
+  } else if (file.endsWith('.html')) {
+    const at = /^<!DOCTYPE/i.test(lines[0] ?? '') ? 1 : 0;
+    lines.splice(at, 0, ...header);
+  } else if (file.endsWith('.go')) {
+    // Blank line after the header keeps it a separate comment group from
+    // any //go:build constraint or doc comment that follows (go/build
+    // requires build constraints to be separated by a blank line).
+    lines.splice(0, 0, ...header, '');
+    while (lines[header.length + 1] === '') lines.splice(header.length + 1, 1);
+  } else {
+    const at = lines[0]?.startsWith('#!') ? 1 : 0;
+    lines.splice(at, 0, ...header);
+  }
+  return lines.join('\n');
+}
+
+function main() {
+  const mode = process.argv[2] === 'fix' ? 'fix' : 'check';
+  const files = execFileSync('git', ['ls-files'], { encoding: 'utf8' })
+    .split('\n').filter(Boolean);
+
+  let missing = 0;
+  let fixed = 0;
+  for (const f of files) {
+    const base = f.split('/').pop();
+    const ext = extOf(f);
+    if (EXCLUDE_BASENAMES.has(base) || EXCLUDE_EXTS.has(ext) ||
+        EXCLUDE_PATHS.has(f) || isGenerated(f) || styleFor(f) === null) continue;
+
+    let content;
+    try {
+      content = readFileSync(f, 'utf8');
+    } catch {
+      continue;
+    }
+    if (content.includes('\u0000')) continue; // binary
+
+    if (mode === 'check') {
+      if (!isHeadered(content.split('\n'))) {
+        console.log(`missing license header: ${f}`);
+        missing++;
+      }
+    } else {
+      if (isHeadered(content.split('\n'))) continue;
+      const out = fixContent(f, content);
+      if (out === null) {
+        console.log(`skipped (no insertion anchor): ${f}`);
+        continue;
+      }
+      writeFileSync(f, out);
+      console.log(`fixed: ${f}`);
+      fixed++;
+    }
+  }
+
+  if (mode === 'check') {
+    if (missing > 0) {
+      console.error(`\n${missing} file(s) missing the license header (run: npm run license:fix)`);
+      process.exit(1);
+    }
+    console.log('license headers: all tracked source files OK');
+  } else {
+    console.log(`\nfixed ${fixed} file(s)`);
+  }
+}
+
+main();

--- a/services/host-agent/.air.toml
+++ b/services/host-agent/.air.toml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 # Air configuration for Go hot reload in Lima VM
 # https://github.com/air-verse/air
 

--- a/services/host-agent/cmd/host-agent/configure.go
+++ b/services/host-agent/cmd/host-agent/configure.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/services/host-agent/cmd/host-agent/init_secrets.go
+++ b/services/host-agent/cmd/host-agent/init_secrets.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/services/host-agent/cmd/host-agent/main.go
+++ b/services/host-agent/cmd/host-agent/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package main
 
 import (

--- a/services/host-agent/cmd/host-agent/scripts/seed_dev_user.py
+++ b/services/host-agent/cmd/host-agent/scripts/seed_dev_user.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 import os
 from authentik.core.models import User, Group
 

--- a/services/host-agent/internal/api/api_test.go
+++ b/services/host-agent/internal/api/api_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/apps_module.go
+++ b/services/host-agent/internal/api/apps_module.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/apps_module_test.go
+++ b/services/host-agent/internal/api/apps_module_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/auth.go
+++ b/services/host-agent/internal/api/auth.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/auth_module.go
+++ b/services/host-agent/internal/api/auth_module.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/auth_module_test.go
+++ b/services/host-agent/internal/api/auth_module_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/auth_test.go
+++ b/services/host-agent/internal/api/auth_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/dev_dashboard.html
+++ b/services/host-agent/internal/api/dev_dashboard.html
@@ -1,4 +1,6 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: AGPL-3.0-only
+     Copyright (c) 2026 Daniel Buckner -->
 <html lang="en">
 <head>
 <meta charset="utf-8">

--- a/services/host-agent/internal/api/home_module.go
+++ b/services/host-agent/internal/api/home_module.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/home_module_test.go
+++ b/services/host-agent/internal/api/home_module_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/logs_module.go
+++ b/services/host-agent/internal/api/logs_module.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/logs_module_test.go
+++ b/services/host-agent/internal/api/logs_module_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/remote_apps_module.go
+++ b/services/host-agent/internal/api/remote_apps_module.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/remote_apps_module_test.go
+++ b/services/host-agent/internal/api/remote_apps_module_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/remote_apps_test.go
+++ b/services/host-agent/internal/api/remote_apps_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/router.go
+++ b/services/host-agent/internal/api/router.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/server.go
+++ b/services/host-agent/internal/api/server.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/settings_module.go
+++ b/services/host-agent/internal/api/settings_module.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/settings_module_test.go
+++ b/services/host-agent/internal/api/settings_module_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/sharing_module.go
+++ b/services/host-agent/internal/api/sharing_module.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/sharing_module_test.go
+++ b/services/host-agent/internal/api/sharing_module_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/system_module.go
+++ b/services/host-agent/internal/api/system_module.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/api/system_module_test.go
+++ b/services/host-agent/internal/api/system_module_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package api
 
 import (

--- a/services/host-agent/internal/appconfig/register.go
+++ b/services/host-agent/internal/appconfig/register.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package appconfig registers all app configurators with the registry.
 package appconfig
 

--- a/services/host-agent/internal/appconfig/traefik.go
+++ b/services/host-agent/internal/appconfig/traefik.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package appconfig
 
 import (

--- a/services/host-agent/internal/catalog/cache.go
+++ b/services/host-agent/internal/catalog/cache.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 import (

--- a/services/host-agent/internal/catalog/catalog_test.go
+++ b/services/host-agent/internal/catalog/catalog_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 import (

--- a/services/host-agent/internal/catalog/graph.go
+++ b/services/host-agent/internal/catalog/graph.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 // AppGraph manages app relationships and dependency resolution

--- a/services/host-agent/internal/catalog/graph_test.go
+++ b/services/host-agent/internal/catalog/graph_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 import (

--- a/services/host-agent/internal/catalog/interfaces.go
+++ b/services/host-agent/internal/catalog/interfaces.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 // CacheInterface defines the interface for app catalog caching.

--- a/services/host-agent/internal/catalog/loader.go
+++ b/services/host-agent/internal/catalog/loader.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 import (

--- a/services/host-agent/internal/catalog/models.go
+++ b/services/host-agent/internal/catalog/models.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 // App represents an application in the catalog

--- a/services/host-agent/internal/catalog/models_test.go
+++ b/services/host-agent/internal/catalog/models_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 import (

--- a/services/host-agent/internal/catalog/plan.go
+++ b/services/host-agent/internal/catalog/plan.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 import "fmt"

--- a/services/host-agent/internal/catalog/plan_test.go
+++ b/services/host-agent/internal/catalog/plan_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 import (

--- a/services/host-agent/internal/catalog/types.go
+++ b/services/host-agent/internal/catalog/types.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package catalog
 
 // AppDefinition represents an application in the catalog

--- a/services/host-agent/internal/config/config.go
+++ b/services/host-agent/internal/config/config.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package config
 
 import (

--- a/services/host-agent/internal/config/config_test.go
+++ b/services/host-agent/internal/config/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package config
 
 import (

--- a/services/host-agent/internal/config/ldap.go
+++ b/services/host-agent/internal/config/ldap.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package config
 
 import "codeberg.org/d-buckner/bloud/services/host-agent/pkg/configurator"

--- a/services/host-agent/internal/config/ldap_test.go
+++ b/services/host-agent/internal/config/ldap_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package config
 
 import (

--- a/services/host-agent/internal/container/runtime.go
+++ b/services/host-agent/internal/container/runtime.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package container
 
 import (

--- a/services/host-agent/internal/container/runtime_test.go
+++ b/services/host-agent/internal/container/runtime_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package container
 
 import (

--- a/services/host-agent/internal/db/db.go
+++ b/services/host-agent/internal/db/db.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package db
 
 import (

--- a/services/host-agent/internal/e2e/e2e_test.go
+++ b/services/host-agent/internal/e2e/e2e_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 //go:build integration
 
 // Package e2e contains integration tests that run against a host-agent

--- a/services/host-agent/internal/graph/graph.go
+++ b/services/host-agent/internal/graph/graph.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package graph manages the lifecycle state graph for installed apps.
 // Each node tracks a targetStatus (desired) and actualStatus (current),
 // and fires events when either changes. Topological ordering ensures

--- a/services/host-agent/internal/graph/graph_test.go
+++ b/services/host-agent/internal/graph/graph_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package graph_test
 
 import (

--- a/services/host-agent/internal/graph/repository.go
+++ b/services/host-agent/internal/graph/repository.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package graph
 
 import (

--- a/services/host-agent/internal/graph/sqlite_repository.go
+++ b/services/host-agent/internal/graph/sqlite_repository.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package graph
 
 import (

--- a/services/host-agent/internal/netutil/ip.go
+++ b/services/host-agent/internal/netutil/ip.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package netutil
 
 import (

--- a/services/host-agent/internal/netutil/ip_test.go
+++ b/services/host-agent/internal/netutil/ip_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package netutil
 
 import (

--- a/services/host-agent/internal/orchestrator/config.go
+++ b/services/host-agent/internal/orchestrator/config.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 // config.go declares the outbound dependency interfaces the orchestrator

--- a/services/host-agent/internal/orchestrator/config_builder.go
+++ b/services/host-agent/internal/orchestrator/config_builder.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/orchestrator/config_builder_test.go
+++ b/services/host-agent/internal/orchestrator/config_builder_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/orchestrator/fakes_test.go
+++ b/services/host-agent/internal/orchestrator/fakes_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/orchestrator/fixtures_test.go
+++ b/services/host-agent/internal/orchestrator/fixtures_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/orchestrator/intent.go
+++ b/services/host-agent/internal/orchestrator/intent.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import "github.com/google/uuid"

--- a/services/host-agent/internal/orchestrator/mocks_test.go
+++ b/services/host-agent/internal/orchestrator/mocks_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/orchestrator/orchestrator.go
+++ b/services/host-agent/internal/orchestrator/orchestrator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/orchestrator/orchestrator_containers.go
+++ b/services/host-agent/internal/orchestrator/orchestrator_containers.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 // Container runtime utilities: container-state sync, route regeneration, and

--- a/services/host-agent/internal/orchestrator/orchestrator_test.go
+++ b/services/host-agent/internal/orchestrator/orchestrator_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/orchestrator/pipeline.go
+++ b/services/host-agent/internal/orchestrator/pipeline.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/orchestrator/pipeline_test.go
+++ b/services/host-agent/internal/orchestrator/pipeline_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/orchestrator/queue.go
+++ b/services/host-agent/internal/orchestrator/queue.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/orchestrator/test_helpers_test.go
+++ b/services/host-agent/internal/orchestrator/test_helpers_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package orchestrator
 
 import (

--- a/services/host-agent/internal/podman/client.go
+++ b/services/host-agent/internal/podman/client.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package podman
 
 import (

--- a/services/host-agent/internal/podman/client_test.go
+++ b/services/host-agent/internal/podman/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package podman
 
 import (

--- a/services/host-agent/internal/schema/schema.go
+++ b/services/host-agent/internal/schema/schema.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package schema holds the single source of truth for the host-agent
 // SQLite schema. Both the production database (db.InitDB) and the test
 // database (testdb) apply the same embedded schema.sql, so the two can

--- a/services/host-agent/internal/schema/schema.sql
+++ b/services/host-agent/internal/schema/schema.sql
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+-- Copyright (c) 2026 Daniel Buckner
 -- Bloud Host Agent Database Schema (SQLite)
 
 CREATE TABLE IF NOT EXISTS apps (

--- a/services/host-agent/internal/secrets/manager.go
+++ b/services/host-agent/internal/secrets/manager.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package secrets
 
 import (

--- a/services/host-agent/internal/secrets/manager_test.go
+++ b/services/host-agent/internal/secrets/manager_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package secrets
 
 import (

--- a/services/host-agent/internal/sharing/gateway.go
+++ b/services/host-agent/internal/sharing/gateway.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sharing
 
 import (

--- a/services/host-agent/internal/sharing/gateway_test.go
+++ b/services/host-agent/internal/sharing/gateway_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sharing
 
 import (

--- a/services/host-agent/internal/sharing/proxy_outpost.go
+++ b/services/host-agent/internal/sharing/proxy_outpost.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sharing
 
 import (

--- a/services/host-agent/internal/sharing/remoteproxy.go
+++ b/services/host-agent/internal/sharing/remoteproxy.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sharing
 
 import (

--- a/services/host-agent/internal/sharing/remoteproxy_test.go
+++ b/services/host-agent/internal/sharing/remoteproxy_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sharing
 
 import (

--- a/services/host-agent/internal/sharing/serve_config.go
+++ b/services/host-agent/internal/sharing/serve_config.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sharing
 
 import "fmt"

--- a/services/host-agent/internal/sharing/tailnet_node.go
+++ b/services/host-agent/internal/sharing/tailnet_node.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sharing
 
 import (

--- a/services/host-agent/internal/sharing/tailnet_node_test.go
+++ b/services/host-agent/internal/sharing/tailnet_node_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sharing
 
 import (

--- a/services/host-agent/internal/sharing/token.go
+++ b/services/host-agent/internal/sharing/token.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sharing
 
 import (

--- a/services/host-agent/internal/sharing/token_test.go
+++ b/services/host-agent/internal/sharing/token_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sharing
 
 import (

--- a/services/host-agent/internal/sso/blueprint.go
+++ b/services/host-agent/internal/sso/blueprint.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sso
 
 import (

--- a/services/host-agent/internal/sso/blueprint_test.go
+++ b/services/host-agent/internal/sso/blueprint_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sso
 
 import (

--- a/services/host-agent/internal/sso/interfaces.go
+++ b/services/host-agent/internal/sso/interfaces.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sso
 
 import (

--- a/services/host-agent/internal/sso/oidc.go
+++ b/services/host-agent/internal/sso/oidc.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package sso
 
 import (

--- a/services/host-agent/internal/store/apps.go
+++ b/services/host-agent/internal/store/apps.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/apps_test.go
+++ b/services/host-agent/internal/store/apps_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/guests.go
+++ b/services/host-agent/internal/store/guests.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/guests_test.go
+++ b/services/host-agent/internal/store/guests_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/interfaces.go
+++ b/services/host-agent/internal/store/interfaces.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 // AppStoreInterface defines the interface for managing installed apps.

--- a/services/host-agent/internal/store/positions.go
+++ b/services/host-agent/internal/store/positions.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/remote_apps.go
+++ b/services/host-agent/internal/store/remote_apps.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/remote_apps_test.go
+++ b/services/host-agent/internal/store/remote_apps_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/sessions.go
+++ b/services/host-agent/internal/store/sessions.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/sessions_test.go
+++ b/services/host-agent/internal/store/sessions_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/shares.go
+++ b/services/host-agent/internal/store/shares.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/shares_test.go
+++ b/services/host-agent/internal/store/shares_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/tailnet.go
+++ b/services/host-agent/internal/store/tailnet.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/tailnet_test.go
+++ b/services/host-agent/internal/store/tailnet_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/store/users.go
+++ b/services/host-agent/internal/store/users.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package store
 
 import (

--- a/services/host-agent/internal/system/monitor.go
+++ b/services/host-agent/internal/system/monitor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package system
 
 import (

--- a/services/host-agent/internal/testdb/testdb.go
+++ b/services/host-agent/internal/testdb/testdb.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package testdb provides test database utilities for SQLite
 package testdb
 

--- a/services/host-agent/internal/traefikgen/generator.go
+++ b/services/host-agent/internal/traefikgen/generator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package traefikgen
 
 import (

--- a/services/host-agent/internal/traefikgen/generator_test.go
+++ b/services/host-agent/internal/traefikgen/generator_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package traefikgen
 
 import (

--- a/services/host-agent/internal/traefikgen/interfaces.go
+++ b/services/host-agent/internal/traefikgen/interfaces.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package traefikgen
 
 import "codeberg.org/d-buckner/bloud/services/host-agent/internal/catalog"

--- a/services/host-agent/pkg/authentik/client.go
+++ b/services/host-agent/pkg/authentik/client.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package authentik
 
 import (

--- a/services/host-agent/pkg/authentik/client_test.go
+++ b/services/host-agent/pkg/authentik/client_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package authentik
 
 import (

--- a/services/host-agent/pkg/authentik/interfaces.go
+++ b/services/host-agent/pkg/authentik/interfaces.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package authentik
 
 // ClientInterface defines the interface for Authentik API operations.

--- a/services/host-agent/pkg/configurator/base.go
+++ b/services/host-agent/pkg/configurator/base.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package configurator
 
 import (

--- a/services/host-agent/pkg/configurator/health.go
+++ b/services/host-agent/pkg/configurator/health.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package configurator
 
 import (

--- a/services/host-agent/pkg/configurator/ini.go
+++ b/services/host-agent/pkg/configurator/ini.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package configurator
 
 import (

--- a/services/host-agent/pkg/configurator/interface.go
+++ b/services/host-agent/pkg/configurator/interface.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package configurator provides the interface and utilities for app configuration.
 // Configurators handle app-specific setup that can't be expressed purely in Nix,
 // such as config file generation and API-based configuration.

--- a/services/host-agent/pkg/configurator/interfaces.go
+++ b/services/host-agent/pkg/configurator/interfaces.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package configurator
 
 // RegistryInterface defines the interface for the node lifecycle registry.

--- a/services/host-agent/pkg/configurator/postgres.go
+++ b/services/host-agent/pkg/configurator/postgres.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package configurator
 
 import (

--- a/services/host-agent/pkg/configurator/registry.go
+++ b/services/host-agent/pkg/configurator/registry.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package configurator
 
 import (

--- a/services/host-agent/pkg/managedfile/write.go
+++ b/services/host-agent/pkg/managedfile/write.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package managedfile provides atomic file writes with change detection.
 package managedfile
 

--- a/services/host-agent/pkg/managedfile/write_test.go
+++ b/services/host-agent/pkg/managedfile/write_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package managedfile
 
 import (

--- a/services/host-agent/pkg/slug/slug.go
+++ b/services/host-agent/pkg/slug/slug.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package slug provides URL-safe slug generation for subdomain routing.
 // This is the single canonical implementation — the frontend has a mirrored
 // version in web/src/lib/utils/appUrl.ts that must produce identical output.

--- a/services/host-agent/pkg/slug/slug_test.go
+++ b/services/host-agent/pkg/slug/slug_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package slug
 
 import (

--- a/services/host-agent/pkg/xmlutil/config.go
+++ b/services/host-agent/pkg/xmlutil/config.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package xmlutil provides utilities for reading and modifying XML configuration files.
 package xmlutil
 

--- a/services/host-agent/pkg/xmlutil/config_test.go
+++ b/services/host-agent/pkg/xmlutil/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 package xmlutil
 
 import (

--- a/services/host-agent/web/playwright.config.ts
+++ b/services/host-agent/web/playwright.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { defineConfig, devices } from '@playwright/test';
 
 /**

--- a/services/host-agent/web/src/app.css
+++ b/services/host-agent/web/src/app.css
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2026 Daniel Buckner
+ */
 /* Bloud Design System */
 @import './lib/styles/fonts.css';
 @import './lib/styles/variables.css';

--- a/services/host-agent/web/src/app.d.ts
+++ b/services/host-agent/web/src/app.d.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {

--- a/services/host-agent/web/src/app.html
+++ b/services/host-agent/web/src/app.html
@@ -1,4 +1,6 @@
 <!DOCTYPE html>
+<!-- SPDX-License-Identifier: AGPL-3.0-only
+     Copyright (c) 2026 Daniel Buckner -->
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />

--- a/services/host-agent/web/src/lib/api/catalog.ts
+++ b/services/host-agent/web/src/lib/api/catalog.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * Catalog API - Raw HTTP calls for app catalog
  */

--- a/services/host-agent/web/src/lib/api/poller.ts
+++ b/services/host-agent/web/src/lib/api/poller.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * Home Poller - Replaces SSE with adaptive polling of GET /api/user/home
  *

--- a/services/host-agent/web/src/lib/clients/appClient.ts
+++ b/services/host-agent/web/src/lib/clients/appClient.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * App Client - HTTP transport layer for app operations
  */

--- a/services/host-agent/web/src/lib/clients/developerClient.ts
+++ b/services/host-agent/web/src/lib/clients/developerClient.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { get } from './httpClient';
 
 export interface GraphNode {

--- a/services/host-agent/web/src/lib/clients/httpClient.ts
+++ b/services/host-agent/web/src/lib/clients/httpClient.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * HTTP Client - Base utilities for API communication
  *

--- a/services/host-agent/web/src/lib/clients/layoutClient.ts
+++ b/services/host-agent/web/src/lib/clients/layoutClient.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * Layout Client - HTTP transport layer for layout save operations.
  *

--- a/services/host-agent/web/src/lib/clients/remoteAppClient.ts
+++ b/services/host-agent/web/src/lib/clients/remoteAppClient.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * Remote App Client - HTTP transport for shared app operations
  */

--- a/services/host-agent/web/src/lib/clients/settingsClient.ts
+++ b/services/host-agent/web/src/lib/clients/settingsClient.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { get, post, del } from './httpClient';
 import type { IntentResponse } from '$lib/types';
 

--- a/services/host-agent/web/src/lib/clients/sharingClient.ts
+++ b/services/host-agent/web/src/lib/clients/sharingClient.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * Sharing Client - HTTP transport for sharing and guest management
  */

--- a/services/host-agent/web/src/lib/clients/userClient.ts
+++ b/services/host-agent/web/src/lib/clients/userClient.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { get, post, put, del } from './httpClient';
 import type { Role } from '$lib/stores/user';
 

--- a/services/host-agent/web/src/lib/components/AddSharedAppModal.svelte
+++ b/services/host-agent/web/src/lib/components/AddSharedAppModal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import Modal from './Modal.svelte';
 	import CloseButton from './CloseButton.svelte';
 	import type { CatalogApp, InvitePayload } from '$lib/types';

--- a/services/host-agent/web/src/lib/components/AppContextMenu.svelte
+++ b/services/host-agent/web/src/lib/components/AppContextMenu.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { onMount, onDestroy } from 'svelte';
 	import { browser } from '$app/environment';
 	import Icon from './Icon.svelte';

--- a/services/host-agent/web/src/lib/components/AppDetailModal.svelte
+++ b/services/host-agent/web/src/lib/components/AppDetailModal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import Modal from './Modal.svelte';
 	import AppIcon from './AppIcon.svelte';
 	import CloseButton from './CloseButton.svelte';

--- a/services/host-agent/web/src/lib/components/AppIcon.svelte
+++ b/services/host-agent/web/src/lib/components/AppIcon.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	interface Props {
 		appName: string;
 		displayName?: string;

--- a/services/host-agent/web/src/lib/components/AppTile.svelte
+++ b/services/host-agent/web/src/lib/components/AppTile.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import AppIcon from './AppIcon.svelte';
 	import { visibleApps, loading } from '$lib/stores/apps';
 	import { type App } from '$lib/types';

--- a/services/host-agent/web/src/lib/components/Button.svelte
+++ b/services/host-agent/web/src/lib/components/Button.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import type { Snippet } from 'svelte';
 
 	interface Props {

--- a/services/host-agent/web/src/lib/components/CatalogAppCard.svelte
+++ b/services/host-agent/web/src/lib/components/CatalogAppCard.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import AppIcon from './AppIcon.svelte';
 	import type { CatalogApp } from '$lib/types';
 

--- a/services/host-agent/web/src/lib/components/CloseButton.svelte
+++ b/services/host-agent/web/src/lib/components/CloseButton.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import IconButton from './IconButton.svelte';
 
 	interface Props {

--- a/services/host-agent/web/src/lib/components/EmptyState.svelte
+++ b/services/host-agent/web/src/lib/components/EmptyState.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import Icon from './Icon.svelte';
 
 	interface Props {

--- a/services/host-agent/web/src/lib/components/ErrorState.svelte
+++ b/services/host-agent/web/src/lib/components/ErrorState.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	interface Props {
 		message?: string;
 	}

--- a/services/host-agent/web/src/lib/components/FitView.svelte
+++ b/services/host-agent/web/src/lib/components/FitView.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { onMount } from 'svelte';
 	import { useSvelteFlow } from '@xyflow/svelte';
 

--- a/services/host-agent/web/src/lib/components/GridStackGrid.svelte
+++ b/services/host-agent/web/src/lib/components/GridStackGrid.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { onMount, onDestroy, mount, unmount } from 'svelte';
 	import { GridStack, type GridStackNode } from 'gridstack';
 	import { gridElements, type GridElement } from '$lib/stores/grid';

--- a/services/host-agent/web/src/lib/components/Icon.svelte
+++ b/services/host-agent/web/src/lib/components/Icon.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	interface Props {
 		name: string;
 		size?: number;

--- a/services/host-agent/web/src/lib/components/IconButton.svelte
+++ b/services/host-agent/web/src/lib/components/IconButton.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import Icon from './Icon.svelte';
 
 	interface Props {

--- a/services/host-agent/web/src/lib/components/LoadingGrid.svelte
+++ b/services/host-agent/web/src/lib/components/LoadingGrid.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	interface Props {
 		count?: number;
 	}

--- a/services/host-agent/web/src/lib/components/Modal.svelte
+++ b/services/host-agent/web/src/lib/components/Modal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import type { Snippet } from 'svelte';
 
 	interface Props {

--- a/services/host-agent/web/src/lib/components/RemoteAppCard.svelte
+++ b/services/host-agent/web/src/lib/components/RemoteAppCard.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import AppIcon from './AppIcon.svelte';
 	import Icon from './Icon.svelte';
 	import type { RemoteApp } from '$lib/types';

--- a/services/host-agent/web/src/lib/components/RenameModal.svelte
+++ b/services/host-agent/web/src/lib/components/RenameModal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import Modal from './Modal.svelte';
 	import CloseButton from './CloseButton.svelte';
 

--- a/services/host-agent/web/src/lib/components/SetupWizard.svelte
+++ b/services/host-agent/web/src/lib/components/SetupWizard.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import Button from './Button.svelte';
 
 	interface SetupStatus {

--- a/services/host-agent/web/src/lib/components/ShareModal.svelte
+++ b/services/host-agent/web/src/lib/components/ShareModal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import Modal from './Modal.svelte';
 	import CloseButton from './CloseButton.svelte';
 	import { createInvite, fetchGuests, createGuest } from '$lib/clients/sharingClient';

--- a/services/host-agent/web/src/lib/components/Sidebar.svelte
+++ b/services/host-agent/web/src/lib/components/Sidebar.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { page } from '$app/state';
 	import Icon from './Icon.svelte';
 	import { isAdmin } from '$lib/stores/user';

--- a/services/host-agent/web/src/lib/components/UninstallModal.svelte
+++ b/services/host-agent/web/src/lib/components/UninstallModal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import Modal from './Modal.svelte';
 	import CloseButton from './CloseButton.svelte';
 

--- a/services/host-agent/web/src/lib/components/WidgetWrapper.svelte
+++ b/services/host-agent/web/src/lib/components/WidgetWrapper.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import Widget from '$lib/widgets/Widget.svelte';
 	import { type WidgetDefinition } from '$lib/widgets/registry';
 

--- a/services/host-agent/web/src/lib/services/appFacade.ts
+++ b/services/host-agent/web/src/lib/services/appFacade.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * App Facade - Unified interface for app operations
  *

--- a/services/host-agent/web/src/lib/stores/apps.ts
+++ b/services/host-agent/web/src/lib/stores/apps.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * Apps Store - Single source of truth for installed app state
  *

--- a/services/host-agent/web/src/lib/stores/grid.ts
+++ b/services/host-agent/web/src/lib/stores/grid.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * Grid store - In-memory source of truth for grid element positions.
  *

--- a/services/host-agent/web/src/lib/stores/user.ts
+++ b/services/host-agent/web/src/lib/stores/user.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { writable, derived } from 'svelte/store';
 
 export type Role = 'admin' | 'member';

--- a/services/host-agent/web/src/lib/styles/base.css
+++ b/services/host-agent/web/src/lib/styles/base.css
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2026 Daniel Buckner
+ */
 /* Bloud Design System - Base Styles */
 
 *, *::before, *::after {

--- a/services/host-agent/web/src/lib/styles/fonts.css
+++ b/services/host-agent/web/src/lib/styles/fonts.css
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2026 Daniel Buckner
+ */
 /* Self-hosted Inter font */
 @font-face {
 	font-family: 'Inter';

--- a/services/host-agent/web/src/lib/styles/variables.css
+++ b/services/host-agent/web/src/lib/styles/variables.css
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2026 Daniel Buckner
+ */
 /* Bloud Design System - CSS Variables */
 
 :root {

--- a/services/host-agent/web/src/lib/types.ts
+++ b/services/host-agent/web/src/lib/types.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 // API Response Types
 
 export type AppStatus = 'running' | 'starting' | 'installing' | 'uninstalling' | 'stopped' | 'error' | 'failed';

--- a/services/host-agent/web/src/lib/utils/appUrl.ts
+++ b/services/host-agent/web/src/lib/utils/appUrl.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 /**
  * Build a subdomain URL for an app based on the current window location.
  * Automatically works for dev (localhost:8080) and prod (bloud.local).

--- a/services/host-agent/web/src/lib/widgets/QuickNotes.svelte
+++ b/services/host-agent/web/src/lib/widgets/QuickNotes.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { browser } from '$app/environment';
 
 	const STORAGE_KEY = 'bloud-quick-notes';

--- a/services/host-agent/web/src/lib/widgets/Storage.svelte
+++ b/services/host-agent/web/src/lib/widgets/Storage.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	interface StorageStats {
 		used: number;
 		total: number;

--- a/services/host-agent/web/src/lib/widgets/SystemStats.svelte
+++ b/services/host-agent/web/src/lib/widgets/SystemStats.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	interface Stats {
 		cpu: number;
 		memory: number;

--- a/services/host-agent/web/src/lib/widgets/Widget.svelte
+++ b/services/host-agent/web/src/lib/widgets/Widget.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import type { Snippet } from 'svelte';
 
 	interface Props {

--- a/services/host-agent/web/src/lib/widgets/WidgetPicker.svelte
+++ b/services/host-agent/web/src/lib/widgets/WidgetPicker.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import Modal from '$lib/components/Modal.svelte';
 	import Button from '$lib/components/Button.svelte';
 	import { widgetRegistry } from './registry';

--- a/services/host-agent/web/src/lib/widgets/__tests__/registry.test.ts
+++ b/services/host-agent/web/src/lib/widgets/__tests__/registry.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { describe, it, expect } from 'vitest';
 import { widgetRegistry, getWidgetById, isValidWidgetId } from '../registry';
 

--- a/services/host-agent/web/src/lib/widgets/registry.ts
+++ b/services/host-agent/web/src/lib/widgets/registry.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import type { Component } from 'svelte';
 import SystemStats from './SystemStats.svelte';
 import Storage from './Storage.svelte';

--- a/services/host-agent/web/src/routes/+layout.svelte
+++ b/services/host-agent/web/src/routes/+layout.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import '../app.css';
 	import type { Snippet } from 'svelte';
 	import { onMount } from 'svelte';

--- a/services/host-agent/web/src/routes/+page.svelte
+++ b/services/host-agent/web/src/routes/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
 	import GridStackGrid from '$lib/components/GridStackGrid.svelte';

--- a/services/host-agent/web/src/routes/catalog/+page.svelte
+++ b/services/host-agent/web/src/routes/catalog/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { onMount } from 'svelte';
 	import CatalogAppCard from '$lib/components/CatalogAppCard.svelte';
 	import AppDetailModal from '$lib/components/AppDetailModal.svelte';

--- a/services/host-agent/web/src/routes/community/+page.svelte
+++ b/services/host-agent/web/src/routes/community/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { onMount } from 'svelte';
 	import { SvelteFlow, type Node, type Edge, type NodeTypes } from '@xyflow/svelte';
 	import dagre from '@dagrejs/dagre';

--- a/services/host-agent/web/src/routes/community/AppIconNode.svelte
+++ b/services/host-agent/web/src/routes/community/AppIconNode.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { Handle, Position } from '@xyflow/svelte';
 	import AppIcon from '$lib/components/AppIcon.svelte';
 

--- a/services/host-agent/web/src/routes/community/PersonNode.svelte
+++ b/services/host-agent/web/src/routes/community/PersonNode.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { Handle, Position } from '@xyflow/svelte';
 
 	interface Props {

--- a/services/host-agent/web/src/routes/developer/+page.svelte
+++ b/services/host-agent/web/src/routes/developer/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { onMount } from 'svelte';
 	import { SvelteFlow, type Node, type Edge, type NodeTypes } from '@xyflow/svelte';
 	import dagre from '@dagrejs/dagre';

--- a/services/host-agent/web/src/routes/developer/AppNode.svelte
+++ b/services/host-agent/web/src/routes/developer/AppNode.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { Handle, Position } from '@xyflow/svelte';
 
 	interface NodeData {

--- a/services/host-agent/web/src/routes/developer/UserNode.svelte
+++ b/services/host-agent/web/src/routes/developer/UserNode.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { Handle, Position } from '@xyflow/svelte';
 
 	interface NodeData {

--- a/services/host-agent/web/src/routes/settings/+page.svelte
+++ b/services/host-agent/web/src/routes/settings/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import {

--- a/services/host-agent/web/static/authentik-branding.css
+++ b/services/host-agent/web/static/authentik-branding.css
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2026 Daniel Buckner
+ */
 /* Bloud Design System for Authentik
  * Served by the Bloud frontend at /authentik-branding.css
  * Referenced from apps/authentik/branding/bloud-brand.yaml via branding_custom_css

--- a/services/host-agent/web/static/embed.go
+++ b/services/host-agent/web/static/embed.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
+
 // Package static exposes embedded static assets for use by Go code.
 package static
 

--- a/services/host-agent/web/svelte.config.js
+++ b/services/host-agent/web/svelte.config.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 

--- a/services/host-agent/web/vite.config.ts
+++ b/services/host-agent/web/vite.config.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2026 Daniel Buckner
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 

--- a/validation.yaml
+++ b/validation.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (c) 2026 Daniel Buckner
 tiers:
   fast:
     commands:
@@ -19,6 +21,9 @@ tiers:
       - id: web-check-host-agent
         cwd: .
         run: npm run check --workspace=@bloud/host-agent-web
+      - id: license-headers
+        cwd: .
+        run: npm run license:check
 
   integration:
     # Commands run inside the guest against the validation runtime deployed
@@ -44,6 +49,8 @@ inference:
     - pattern: "e2e/**"
       triggers: []
       riskAreas: [playwright]
+    - pattern: "**"
+      triggers: [license-headers]
 
 apps:
   immich:


### PR DESCRIPTION
Stamp every tracked source file with the SPDX identifier plus copyright header, and keep it enforced:

- scripts/license-header.mjs: check/fix tool (per-language syntax; .svelte files carry the header inside <script>)
- npm run license:check now runs first in test:precommit (husky)
- validation.yaml: license-headers command in the fast tier, with a catch-all inference rule so any changed file triggers it

Excluded: JSON, go.mod/go.sum, docs, binaries, *.golden.yml testdata, and the runtime-managed apps-routes.yml (it has its own banner).